### PR TITLE
Rigid body rotational disorder

### DIFF
--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -35,7 +35,7 @@ def generate_grid(A_inv, hsampling, ksampling, lsampling):
     hkl_grid = hkl_grid.T.reshape(-1,3)
     hkl_grid = hkl_grid[:, [2,1,0]]
     
-    q_grid = 2*np.pi*np.inner(A_inv, hkl_grid).T
+    q_grid = 2*np.pi*np.inner(A_inv.T, hkl_grid).T
     return q_grid, map_shape
 
 def visualize_central_slices(I, vmax_scale=5):

--- a/eryx/pdb.py
+++ b/eryx/pdb.py
@@ -163,6 +163,7 @@ class AtomicModel:
         if len(transformations) == 0:
             transformations = sym_ops
 
+        self.n_asu = len(transformations)
         return sym_ops, transformations
     
     def extract_frame(self, expand_p1=False, frame=0):
@@ -186,7 +187,8 @@ class AtomicModel:
             frange = range(len(self.structure))
         else:
             frange = [frame]
-                    
+        self.n_conf = len(frange)
+            
         for fr in frange:
             model = self.structure[fr]
             residues = [res for ch in model for res in ch]

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -43,7 +43,7 @@ class TestScatter(object):
         calc_x = gemmi.StructureFactorCalculatorX(structure.cell)
         sf_ref = np.array(calc_x.calculate_sf_from_model(structure[0], hkl))
         A_inv = np.array(structure.cell.fractionalization_matrix)
-        q_vec = 2*np.pi*np.inner(A_inv, np.array(hkl))
+        q_vec = 2*np.pi*np.inner(A_inv.T, np.array(hkl))
         sf = scatter.structure_factors(np.array([q_vec]), self.model.xyz, self.model.ff_a, self.model.ff_b, self.model.ff_c, U=None)
         assert np.allclose(sf, sf_ref)
         


### PR DESCRIPTION
A class to compute the diffuse scattering that results from rigid body rotational disorder and an associated unit test have been added. In addition a missing transpose operation was added in the calculation of q-vectors. Note this only affects non-orthogonal unit cells.