### PR TITLE
Symmetrization in reciprocal space

### DIFF
--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -93,7 +93,7 @@ def get_ravel_indices(hkl_grid_sym, sampling):
     hkl_grid_int = hkl_grid_int.reshape(hkl_grid_sym.shape)
     
     ravel = np.zeros(hkl_grid_sym.shape[:2]).astype(int)
-    for i in range(model.n_asu):
+    for i in range(ravel.shape[0]):
         ravel[i] = np.ravel_multi_index((hkl_grid_int[i] - lbounds).T, map_shape_ravel)
 
     return ravel

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,13 +25,22 @@ class TestTransforms:
                                                  self.hsampling,
                                                  self.ksampling,
                                                  self.lsampling,
-                                                 expand_p1=True)
+                                                 expand_p1=True,
+                                                 symmetrize='real')
         q_grid, I2 = compute_molecular_transform(self.pdb_path_p1,
                                                  self.hsampling,
                                                  self.ksampling,
                                                  self.lsampling,
-                                                 expand_p1=False)
+                                                 expand_p1=False,
+                                                 symmetrize='real')
+        q_grid, I3 = compute_molecular_transform(self.pdb_path_p1,
+                                                 self.hsampling,
+                                                 self.ksampling,
+                                                 self.lsampling,
+                                                 expand_p1=False,
+                                                 symmetrize='reciprocal')
         assert np.allclose(I1, I2)
+        assert np.allclose(I1, I3)
 
     def test_crystal_transform(self):
         """ Check crystal trnasform calculation. """


### PR DESCRIPTION
Aside from P 1 crystals, symmetrizing in reciprocal rather than real space should save time by reducing the number of q-vectors that must be evaluated in the structure factor calculation. This is now implemented for calculating the molecular transform but should also be extended to the rigid body rotation and ensemble models that rely on Guinier's equation.