### PR TITLE
Additional statistics

### DIFF
--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import numpy as np
 
 def generate_grid(A_inv, hsampling, ksampling, lsampling, return_hkl=False):
@@ -166,37 +165,6 @@ def get_hkl_extents(cell, resolution, oversampling=1):
     g_cell = gemmi.UnitCell(*cell)
     h,k,l = g_cell.get_hkl_limits(resolution)
     return (-h,h,oversampling[0]), (-k,k,oversampling[1]), (-l,l,oversampling[2])
-
-def visualize_central_slices(I, vmax_scale=5):
-    """
-    Plot input map's central slices, assuming that map
-    is centered around h,k,l=(0,0,0).
-
-    Parameters
-    ----------
-    I : numpy.ndarray, 3d
-        intensity map
-    vmax_scale : float
-        vmax will be vmax_scale*mean(I)
-    """
-    f, (ax1,ax2,ax3) = plt.subplots(1, 3, figsize=(12,4))
-    map_shape = I.shape
-    
-    ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=I.mean()*vmax_scale)
-    ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=I.mean()*vmax_scale)
-    ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=I.mean()*vmax_scale)
-
-    ax1.set_aspect(map_shape[2]/map_shape[1])
-    ax2.set_aspect(map_shape[2]/map_shape[0])
-    ax3.set_aspect(map_shape[1]/map_shape[0])
-
-    ax1.set_title("(0,k,l)", fontsize=14)
-    ax2.set_title("(h,0,l)", fontsize=14)
-    ax3.set_title("(h,k,0)", fontsize=14)
-
-    for ax in [ax1,ax2,ax3]:
-        ax.set_xticks([])
-        ax.set_yticks([])
 
 def pearson_cc(arr1, arr2):
     """

--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -166,28 +166,3 @@ def get_hkl_extents(cell, resolution, oversampling=1):
     h,k,l = g_cell.get_hkl_limits(resolution)
     return (-h,h,oversampling[0]), (-k,k,oversampling[1]), (-l,l,oversampling[2])
 
-def pearson_cc(arr1, arr2):
-    """
-    Compute the Pearson correlation-coefficient between the input arrays.
-    Voxels that should be ignored are assumed to have a value of NaN.
-    
-    Parameters
-    ----------
-    arr1 : numpy.ndarray, shape (n_samples, n_points)
-        input array
-    arr2 : numpy.ndarray, shape (n_samples, n_points) or (1, n_points)
-        input array to compute CC with
-    
-    Returns
-    -------
-    ccs : numpy.ndarray, shape (n_samples)
-        correlation coefficient between paired sample arrays, or if
-        arr2.shape[0] == 1, then between each sample of arr1 to arr2
-    """
-    mask = np.isnan(np.sum(np.vstack((arr1, arr2)), axis=0))
-    arr1_m, arr2_m = arr1[:,~mask], arr2[:,~mask]
-    vx = arr1_m - arr1_m.mean(axis=-1)[:,None]
-    vy = arr2_m - arr2_m.mean(axis=-1)[:,None]
-    numerator = np.sum(vx * vy, axis=1)
-    denom = np.sqrt(np.sum(vx**2, axis=1)) * np.sqrt(np.sum(vy**2, axis=1))
-    return numerator / denom

--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -290,7 +290,9 @@ def get_resolution_mask(cell, hkl_grid, res_limit):
     -------
     res_mask : numpy.ndarray, shape (n_points,)
         True indicates hkls that are within high resolution limit
+    res_map : numpy.ndarray, shape (n_points,)
+        resolution in Angstrom for each point in the grid
     """
     res_map = compute_resolution(cell, hkl_grid)
     res_mask = res_map > res_limit
-    return res_mask
+    return res_mask, res_map

--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -296,3 +296,26 @@ def get_resolution_mask(cell, hkl_grid, res_limit):
     res_map = compute_resolution(cell, hkl_grid)
     res_mask = res_map > res_limit
     return res_mask, res_map
+
+def get_dq_map(A_inv, hkl_grid):
+    """
+    Compute dq, the distance to the nearest Bragg peak, for 
+    each reciprocal grid point.
+    
+    Parameters
+    ----------
+    A_inv : numpy.ndarray, shape (3,3)
+        fractional cell orthogonalization matrix
+    hkl_grid : numpy.ndarray, shape (n_points, 3)
+        grid of hkl indices
+    
+    Returns
+    -------
+    dq : numpy.ndarray, shape (n_points,)
+        distance to the nearest Bragg peak
+    """
+    hkl_closest = np.around(hkl_grid)
+    q_closest = 2*np.pi*np.inner(A_inv.T, hkl_closest).T 
+    q_grid = 2*np.pi*np.inner(A_inv.T, hkl_grid).T 
+    dq = np.linalg.norm(np.abs(q_closest - q_grid), axis=1)
+    return np.around(dq, decimals=8)

--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -271,3 +271,26 @@ def get_asu_mask(space_group, hkl_grid):
     h, k, l = [hkl_grid[:,i] for i in range(3)]
     asu_mask = eval(asu_condition)
     return asu_mask
+
+def get_resolution_mask(cell, hkl_grid, res_limit):
+    """
+    Generate a boolean mask that indicates which hkl indices belong
+    to the asymmetric unit.
+    
+    Parameters
+    ----------
+    space_group : int or str
+        crystal's space group
+    hkl_grid : numpy.ndarray, shape (n_points, 3)
+        hkl indices 
+    res_limit : float
+        high resolution limit in Angstrom
+        
+    Returns
+    -------
+    res_mask : numpy.ndarray, shape (n_points,)
+        True indicates hkls that are within high resolution limit
+    """
+    res_map = compute_resolution(cell, hkl_grid)
+    res_mask = res_map > res_limit
+    return res_mask

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -4,6 +4,7 @@ import scipy.spatial
 from .pdb import AtomicModel
 from .map_utils import *
 from .scatter import structure_factors
+from .stats import pearson_cc
 
 def compute_crystal_transform(pdb_path, hsampling, ksampling, lsampling, U=None, batch_size=10000, expand_p1=True):
     """

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -4,7 +4,7 @@ import scipy.spatial
 from .pdb import AtomicModel
 from .map_utils import *
 from .scatter import structure_factors
-from .stats import pearson_cc
+from .stats import compute_cc
 
 def compute_crystal_transform(pdb_path, hsampling, ksampling, lsampling, U=None, batch_size=10000, expand_p1=True):
     """
@@ -253,7 +253,7 @@ class TranslationalDisorder:
             sigmas = np.array(list(itertools.product(sa, sb, sc)))
         
         Id = self.apply_disorder(sigmas)
-        ccs = pearson_cc(Id, np.expand_dims(target.flatten(), axis=0))
+        ccs = compute_cc(Id, np.expand_dims(target.flatten(), axis=0))
         opt_index = np.argmax(ccs)
         self.opt_sigma = sigmas[opt_index]
         self.opt_map = Id[opt_index].reshape(self.map_shape)
@@ -418,7 +418,7 @@ class LiquidLikeMotions:
         
         Id = self.apply_disorder(sigmas, gammas)
         Id = Id[:,self.mask.flatten()==1]
-        ccs = pearson_cc(Id, np.expand_dims(target.flatten(), axis=0))
+        ccs = compute_cc(Id, np.expand_dims(target.flatten(), axis=0))
         opt_index = np.argmax(ccs)
         self.opt_map = Id[opt_index].reshape(self.map_shape_nopad)
         
@@ -593,7 +593,7 @@ class RotationalDisorder:
         
         sigmas = np.linspace(sigma_min, sigma_max, n_search)        
         Id = self.apply_disorder(sigmas, num_rot)
-        ccs = pearson_cc(Id, np.expand_dims(target.flatten(), axis=0))
+        ccs = compute_cc(Id, np.expand_dims(target.flatten(), axis=0))
         opt_index = np.argmax(ccs)
         self.opt_sigma = sigmas[opt_index]
         self.opt_map = Id[opt_index].reshape(self.map_shape)

--- a/eryx/stats.py
+++ b/eryx/stats.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-def pearson_cc(arr1, arr2):
+def compute_cc(arr1, arr2, mask=None):
     """
-    Compute the Pearson correlation-coefficient between the input arrays.
+    Compute the Pearson correlation coefficient between the input arrays.
     Voxels that should be ignored are assumed to have a value of NaN.
     
     Parameters
@@ -11,6 +11,8 @@ def pearson_cc(arr1, arr2):
         input array
     arr2 : numpy.ndarray, shape (n_samples, n_points) or (1, n_points)
         input array to compute CC with
+    mask : numpy.ndarray, shape (map_shape) or (n_points,)
+        e.g. to select asu/resolution. True values indicate retained grid points
     
     Returns
     -------
@@ -18,10 +20,56 @@ def pearson_cc(arr1, arr2):
         correlation coefficient between paired sample arrays, or if
         arr2.shape[0] == 1, then between each sample of arr1 to arr2
     """
-    mask = np.isnan(np.sum(np.vstack((arr1, arr2)), axis=0))
-    arr1_m, arr2_m = arr1[:,~mask], arr2[:,~mask]
+    if len(arr1.shape) == 1:
+        arr1 = np.array([arr1])
+    if len(arr2.shape) == 1:
+        arr2 = np.array([arr2])
+    
+    valid = ~np.isnan(np.sum(np.vstack((arr1, arr2)), axis=0))
+    if mask is not None:
+        valid *= mask.flatten()
+    arr1_m, arr2_m = arr1[:,valid], arr2[:,valid]
     vx = arr1_m - arr1_m.mean(axis=-1)[:,None]
     vy = arr2_m - arr2_m.mean(axis=-1)[:,None]
     numerator = np.sum(vx * vy, axis=1)
     denom = np.sqrt(np.sum(vx**2, axis=1)) * np.sqrt(np.sum(vy**2, axis=1))
     return numerator / denom
+
+def compute_cc_by_shell(arr1, arr2, res_map, mask=None, n_shells=10):
+    """
+    Compute the Pearson correlation coefficient by resolution shell between the 
+    input arrays. The bin widths of resolutions shells are uniform in d^-3. 
+    
+    Parameters
+    ----------
+    arr1 : numpy.ndarray, shape (n_samples, n_points)
+        input array
+    arr2 : numpy.ndarray, shape (n_samples, n_points) or (1, n_points)
+        input array to compute CC with
+    mask : numpy.ndarray, shape (map_shape) or (n_points,)
+        e.g. to select asu/resolution. True values indicate retained grid points
+    n_shells : int
+        number of resolution bins
+    
+    Returns
+    -------
+    res_shell : numpy.ndarray, shape (n_shells,)
+        median resolution of each resolution shell
+    cc_shell : numpy.ndarray, shape (n_shells,)
+        correlation coefficient by resolution shell
+    """
+    if mask is None:
+        mask = np.ones(res_map.shape).astype(bool)
+        
+    inv_dcubed = 1.0 / (res_map ** 3.0)
+    res_limit = res_map[mask].min()
+    hist, bin_edges = np.histogram(inv_dcubed[res_map>res_limit], bins=n_shells)
+    ind = np.digitize(inv_dcubed, bin_edges)
+    
+    cc_shell, res_shell = np.zeros(n_shells), np.zeros(n_shells)
+    for i in range(1, n_shells+1):
+        arr1_sel, arr2_sel, mask_sel = arr1[ind==i], arr2[ind==i], mask[ind==i]
+        cc_shell[i-1] = compute_cc(arr1_sel, arr2_sel, mask=mask_sel)[0]
+        res_shell[i-1] = np.median(res_map[ind==i])
+        
+    return res_shell, cc_shell

--- a/eryx/stats.py
+++ b/eryx/stats.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+def pearson_cc(arr1, arr2):
+    """
+    Compute the Pearson correlation-coefficient between the input arrays.
+    Voxels that should be ignored are assumed to have a value of NaN.
+    
+    Parameters
+    ----------
+    arr1 : numpy.ndarray, shape (n_samples, n_points)
+        input array
+    arr2 : numpy.ndarray, shape (n_samples, n_points) or (1, n_points)
+        input array to compute CC with
+    
+    Returns
+    -------
+    ccs : numpy.ndarray, shape (n_samples)
+        correlation coefficient between paired sample arrays, or if
+        arr2.shape[0] == 1, then between each sample of arr1 to arr2
+    """
+    mask = np.isnan(np.sum(np.vstack((arr1, arr2)), axis=0))
+    arr1_m, arr2_m = arr1[:,~mask], arr2[:,~mask]
+    vx = arr1_m - arr1_m.mean(axis=-1)[:,None]
+    vy = arr2_m - arr2_m.mean(axis=-1)[:,None]
+    numerator = np.sum(vx * vy, axis=1)
+    denom = np.sqrt(np.sum(vx**2, axis=1)) * np.sqrt(np.sum(vy**2, axis=1))
+    return numerator / denom

--- a/eryx/stats.py
+++ b/eryx/stats.py
@@ -42,9 +42,9 @@ def compute_cc_by_shell(arr1, arr2, res_map, mask=None, n_shells=10):
     
     Parameters
     ----------
-    arr1 : numpy.ndarray, shape (n_samples, n_points)
+    arr1 : numpy.ndarray, shape (n_points,)
         input array
-    arr2 : numpy.ndarray, shape (n_samples, n_points) or (1, n_points)
+    arr2 : numpy.ndarray, shape (n_points,) 
         input array to compute CC with
     mask : numpy.ndarray, shape (map_shape) or (n_points,)
         e.g. to select asu/resolution. True values indicate retained grid points
@@ -58,8 +58,10 @@ def compute_cc_by_shell(arr1, arr2, res_map, mask=None, n_shells=10):
     cc_shell : numpy.ndarray, shape (n_shells,)
         correlation coefficient by resolution shell
     """
+    arr1, arr2 = arr1.flatten(), arr2.flatten()
     if mask is None:
         mask = np.ones(res_map.shape).astype(bool)
+    mask *= ~np.isnan(np.sum(np.vstack((arr1, arr2)), axis=0))
         
     inv_dcubed = 1.0 / (res_map ** 3.0)
     res_limit = res_map[mask].min()

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -1,0 +1,33 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+def visualize_central_slices(I, vmax_scale=5):
+    """
+    Plot central slices from the input map,  assuming
+    that the map is centered around h,k,l=(0,0,0).
+
+    Parameters
+    ----------
+    I : numpy.ndarray, 3d
+        intensity map
+    vmax_scale : float
+        vmax will be vmax_scale*mean(I)
+    """
+    f, (ax1,ax2,ax3) = plt.subplots(1, 3, figsize=(12,4))
+    map_shape = I.shape
+    
+    ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=I.mean()*vmax_scale)
+    ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=I.mean()*vmax_scale)
+    ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=I.mean()*vmax_scale)
+
+    ax1.set_aspect(map_shape[2]/map_shape[1])
+    ax2.set_aspect(map_shape[2]/map_shape[0])
+    ax3.set_aspect(map_shape[1]/map_shape[0])
+
+    ax1.set_title("(0,k,l)", fontsize=14)
+    ax2.set_title("(h,0,l)", fontsize=14)
+    ax3.set_title("(h,k,0)", fontsize=14)
+
+    for ax in [ax1,ax2,ax3]:
+        ax.set_xticks([])
+        ax.set_yticks([])

--- a/tests/test_map_utils.py
+++ b/tests/test_map_utils.py
@@ -1,0 +1,50 @@
+import numpy as np
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from eryx.pdb import AtomicModel
+import eryx.map_utils as map_utils
+
+def setup_model(case):
+    """ Return variables for a test case in the given space group. """
+    
+    if case == 'orthorhombic':
+        hsampling = (-5,5,3)
+        ksampling = (-17,17,2)
+        lsampling = (-30,30,2)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/5zck.pdb"
+
+    elif case == 'trigonal':
+        hsampling = (-27,27,2)
+        ksampling = (-27,27,2)
+        lsampling = (-5,5,3)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/7n2h.pdb"
+
+    elif case == 'triclinic':
+        hsampling = (-14, 14, 2)
+        ksampling = (-5, 5, 2)
+        lsampling = (-15, 15, 2)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/2ol9.pdb"
+        
+    else:
+        raise ValueError("Currently only orthorhombic, trigonal, and triclinic are supported.")
+    
+    model = AtomicModel(pdb_path, expand_p1=False)
+    return model, hsampling, ksampling, lsampling
+
+def test_compute_multiplicity():
+    """ Test that the correct multiplicity values are assigned to hkl indices. """
+
+    for case in ['orthorhombic', 'triclinic']:
+        model, hsampling, ksampling, lsampling = setup_model(case)
+        hkl_grid, multiplicity = map_utils.compute_multiplicity(model, hsampling, ksampling, lsampling)
+        zeros = 3 - np.count_nonzero(hkl_grid, axis=1)
+        
+        if case == 'orthorhombic':
+            assert np.allclose(multiplicity.flatten()[zeros==0], 8)
+            assert np.allclose(multiplicity.flatten()[zeros==1], 4)
+            assert np.allclose(multiplicity.flatten()[zeros==2], 2)
+            
+        if case == 'triclinic':
+            assert np.allclose(multiplicity.flatten()[zeros!=3], 2)

--- a/tests/test_map_utils.py
+++ b/tests/test_map_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import gemmi
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -13,20 +14,26 @@ def setup_model(case):
         hsampling = (-5,5,3)
         ksampling = (-17,17,2)
         lsampling = (-30,30,2)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/5zck.pdb"
+        pdb_path = "pdbs/5zck.pdb"
 
     elif case == 'trigonal':
         hsampling = (-27,27,2)
         ksampling = (-27,27,2)
         lsampling = (-5,5,3)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/7n2h.pdb"
+        pdb_path = "pdbs/7n2h.pdb"
 
     elif case == 'triclinic':
         hsampling = (-14, 14, 2)
         ksampling = (-5, 5, 2)
         lsampling = (-15, 15, 2)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/2ol9.pdb"
+        pdb_path = "pdbs/2ol9.pdb"
         
+    elif case == 'tetragonal':
+        hsampling = (-30, 30, 1)
+        ksampling = (-30, 30, 1)
+        lsampling = (-16, 16, 1)
+        pdb_path = "pdbs/193l.pdb"   
+
     else:
         raise ValueError("Currently only orthorhombic, trigonal, and triclinic are supported.")
     
@@ -48,3 +55,15 @@ def test_compute_multiplicity():
             
         if case == 'triclinic':
             assert np.allclose(multiplicity.flatten()[zeros!=3], 2)
+
+def test_get_asu_mask():
+    """ Test that reflections belonging to the asymmetric unit are correctly identified. """
+
+    for case in ['orthorhombic', 'triclinic', 'orthorhombic', 'trigonal']:
+        model, hsampling, ksampling, lsampling = setup_model(case)
+        hkl_grid, map_shape = map_utils.generate_grid(model.A_inv, (-1,1,1), (-1,1,1), (-1,1,1), return_hkl=True)
+        mask = map_utils.get_asu_mask(model.space_group, hkl_grid)
+        hkl_asu = hkl_grid[mask].astype(int)
+
+        asu = gemmi.ReciprocalAsu(gemmi.SpaceGroup(model.space_group))
+        assert all([asu.is_in(list(h)) for h in hkl_asu])

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,23 @@
+import numpy as np
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import eryx.stats as stats
+
+def test_compute_cc():
+    """ Check that Pearson correlation coefficient is correctly calculated. """
+    
+    # check when all values of arrays are valid
+    a = np.random.randn(18).reshape(3,6)
+    b = np.array([np.random.randn(6)])
+    est_cc = stats.compute_cc(a,b)
+    ref_cc = [np.corrcoef(a[i], b[0])[0,1] for i in range(a.shape[0])]
+    assert np.allclose(est_cc, ref_cc)
+    
+    # check when there's a nan value
+    index = np.random.randint(0, high=a.shape[1])
+    b[:,index] = np.nan
+    est_cc = stats.compute_cc(a,b)
+    ref_cc = [np.corrcoef(a[i][~np.isnan(b[0])], b[0][~np.isnan(b[0])])[0,1] for i in range(a.shape[0])]
+    assert np.allclose(est_cc, ref_cc)


### PR DESCRIPTION
In addition to the overall correlation coefficient (CC), CC(**q**) and CC(**dq**) have been added. For the former, resolution shells have equal width in 1/d^3; for the latter, **dq** corresponds to the distance between the grid point and the nearest integral Miller index. Previously the CC calculation excluded values of NaN; now these CC calculations also accept a mask to enable limiting the calculation to a certain resolution threshold and the asymmetric unit. This combined mask can be generated as follows:
```
asu_mask = map_utils.get_asu_mask(model.space_group, hkl_grid)
res_mask, res_map = map_utils.get_resolution_mask(model.cell, hkl_grid, res_limit)
comb_mask = asu_mask * res_mask
```
There's also a function to determine the multiplicity of each reciprocal grid point, but it's more efficient to compute the CC from the reciprocal asymmetric unit rather than multiplicity-weight the correlation coefficient calculation. CC-related functions are now in stats.py, while `visualize_central_slices` has been moved to visuals.py