### PR TITLE
Molecular transform overhaul

### DIFF
--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -84,6 +84,8 @@ def get_ravel_indices(hkl_grid_sym, sampling):
     -------
     ravel : numpy.ndarray, shape (n_asu, n_points)
         indices in raveled space for hkl_grid_sym
+    map_shape_ravel : tuple, shape (3,)  
+        shape of expanded / raveled map
     """
     hkl_grid_stacked = hkl_grid_sym.reshape(-1, hkl_grid_sym.shape[-1])
     hkl_grid_int = np.around(hkl_grid_stacked * np.array(sampling)).astype(int)
@@ -96,7 +98,7 @@ def get_ravel_indices(hkl_grid_sym, sampling):
     for i in range(ravel.shape[0]):
         ravel[i] = np.ravel_multi_index((hkl_grid_int[i] - lbounds).T, map_shape_ravel)
 
-    return ravel
+    return ravel, map_shape_ravel
 
 def cos_sq(angles):
     """ Compute cosine squared of input angles in radians. """
@@ -208,8 +210,8 @@ def compute_multiplicity(model, hsampling, ksampling, lsampling):
     sym_ops_exp = expand_sym_ops(model.sym_ops)
     hkl_grid, map_shape = generate_grid(model.A_inv, hsampling, ksampling, lsampling, return_hkl=True)
     hkl_sym = get_symmetry_equivalents(hkl_grid, sym_ops_exp)
-    ravel = get_ravel_indices(hkl_sym, (hsampling[2], ksampling[2], lsampling[2])).T
-    multiplicity = (np.diff(np.sort(ravel,axis=1),axis=1)!=0).sum(axis=1)+1
+    ravel, map_shape_ravel = get_ravel_indices(hkl_sym, (hsampling[2], ksampling[2], lsampling[2]))
+    multiplicity = (np.diff(np.sort(ravel.T,axis=1),axis=1)!=0).sum(axis=1)+1
     return hkl_grid, multiplicity.reshape(map_shape)
 
 def parse_asu_condition(asu_condition):

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -49,12 +49,18 @@ def compute_crystal_transform(pdb_path, hsampling, ksampling, lsampling, U=None,
                                            batch_size=batch_size)))
     return q_grid, I.reshape(map_shape)
 
-def compute_molecular_transform(pdb_path, hsampling, ksampling, lsampling, U=None, batch_size=10000, expand_p1=True, symmetrize='reciprocal'):
+def compute_molecular_transform(pdb_path, hsampling, ksampling, lsampling, U=None, 
+                                expand_p1=True, batch_size=10000, expand_friedel=True, res_limit=0):
     """
-    Compute the molecular transform as the incoherent sum
-    of the asymmetric units. If expand_p1 is False, it is
-    assumed that the pdb contains the asymmetric units as
-    separate frames / models.
+    Compute the molecular transform as the incoherent sum of the 
+    asymmetric units. If expand_p1 is False, the pdb is assumed 
+    to contain the asymmetric units as separate frames / models.
+    The calculation is accelerated by leveraging symmetry in one
+    of two ways, one of which will maintain the input grid extents
+    (expand_friedel=False), while the other will output a map that 
+    includes the volume of reciprocal space related by Friedel's law.
+    If h/k/lsampling are symmetric about (0,0,0), these approaches 
+    will yield identical maps.
     
     Parameters
     ----------
@@ -68,12 +74,14 @@ def compute_molecular_transform(pdb_path, hsampling, ksampling, lsampling, U=Non
         (lmin, lmax, oversampling) relative to Miller indices
     U : numpy.ndarray, shape (n_atoms,)
         isotropic displacement parameters, applied to each asymmetric unit
-    batch_size : int
-        number of q-vectors to evaluate per batch
     expand_p1 : bool
         if True, expand PDB (asymmetric unit) to unit cell
-    symmetrize : str
-        symmetrization mode, either real or reciprocal
+    batch_size : int
+        number of q-vectors to evaluate per batch
+    expand_friedel : bool
+        if True, expand to full sphere in reciprocal space
+    res_limit : float
+        high resolution limit
         
     Returns
     -------
@@ -82,62 +90,124 @@ def compute_molecular_transform(pdb_path, hsampling, ksampling, lsampling, U=Non
     I : numpy.ndarray, 3d
         intensity map of the molecular transform
     """
-    if symmetrize == 'real':
-        model = AtomicModel(pdb_path, expand_p1=expand_p1, frame=-1)
-        q_grid, map_shape = generate_grid(model.A_inv, hsampling, ksampling, lsampling)
+    model = AtomicModel(pdb_path, expand_p1=expand_p1)
+    hkl_grid, map_shape = generate_grid(model.A_inv, 
+                                        hsampling,
+                                        ksampling, 
+                                        lsampling, 
+                                        return_hkl=True)
+    q_grid = 2*np.pi*np.inner(model.A_inv.T, hkl_grid).T
+    mask, res_map = get_resolution_mask(model.cell, hkl_grid, res_limit)
+    sampling = (hsampling[2], ksampling[2], lsampling[2])
     
-        I = np.zeros(q_grid.shape[0])
-        for asu in range(model.xyz.shape[0]):
-            I += np.square(np.abs(structure_factors(q_grid,
-                                                    model.xyz[asu],
-                                                    model.ff_a[asu], 
-                                                    model.ff_b[asu], 
-                                                    model.ff_c[asu], 
-                                                    U=U, 
-                                                    batch_size=batch_size)))
-    elif symmetrize == 'reciprocal':
-        model = AtomicModel(pdb_path, expand_p1=False, frame=0)
-        q_grid, map_shape = generate_grid(model.A_inv, hsampling, ksampling, lsampling)
-        I = incoherent_from_reciprocal(model, hsampling, ksampling, lsampling, U=U, batch_size=batch_size)
+    if expand_friedel:
+        I = incoherent_sum_real(model, hkl_grid, sampling, U, batch_size, mask)
+    else:
+        I = incoherent_sum_reciprocal(model, hkl_grid, sampling, U, batch_size)
+        I = I.reshape(map_shape)
+        I[~mask.reshape(map_shape)] = 0
 
-    else: 
-        raise ValueError("Symmetrize must be real or reciprocal")
-        
-    return q_grid, I.reshape(map_shape)
+    return q_grid, I
 
-def incoherent_from_reciprocal(model, hsampling, ksampling, lsampling, U=None, batch_size=10000):
+def incoherent_sum_real(model, hkl_grid, sampling, U=None, batch_size=10000, mask=None):
     """
-    Compute intensities as the incoherent sum of the scattering
-    from asymmetric units by symmetrizing in reciprocal space.
-    This reduces the number of q-vectors to evaluate by up to the
-    number of asymmetric units. The strategy is to determine each
-    reflection's set of symmetry-equivalents, map these 3d vectors
-    to 1d space by raveling, and then computing the intensity only
-    for hkl grid points that haven't already been processed. 
+    Compute the incoherent sum of the scattering from all asus.
+    The scattering for the unique reciprocal wedge is computed 
+    by summing over all asymmetric units in real space, and then
+    using symmetry to extend the calculation to the remainder of
+    the map (including the portion of reciprocal space related by
+    Friedel's law even if not spanned by the input hkl_grid).
     
     Parameters
     ----------
-    model : AtomicModel 
-        instance of AtomicModel class
-    hsampling : tuple, shape (3,)
-        (min, max, interval) along h axis
-    ksampling : tuple, shape (3,)
-        (min, max, interval) along k axis
-    lsampling : tuple, shape (3,)
-        (min, max, interval) along l axis        
+    model : AtomicModel
+        instance of AtomicModel class expanded to p1
+    hkl_grid : numpy.ndarray, shape (n_points, 3)
+        hkl vectors of map grid points
+    sampling : tuple
+        sampling frequency along h,k,l axes
     U : numpy.ndarray, shape (n_atoms,)
         isotropic displacement parameters, applied to each asymmetric unit
     batch_size : int
         number of q-vectors to evaluate per batch
-
+    mask : numpy.ndarray, shape (n_points,)
+        boolean mask, where True indicates grid points to keep
+        
     Returns
     -------
     I : numpy.ndarray, 3d
-        symmetrized intensity map
+        intensity map of the molecular transform
     """
-    hkl_grid, map_shape = generate_grid(model.A_inv, hsampling, ksampling, lsampling, return_hkl=True)
+    # generate asu mask and combine with resolution mask
+    if mask is None:
+        mask = np.ones(hkl_grid.shape[0]).astype(bool)
+    mask *= get_asu_mask(model.space_group, hkl_grid)
+    
+    # sum over asus to compute scattering for unique reciprocal wedge
+    q_grid = 2*np.pi*np.inner(model.A_inv.T, hkl_grid).T
+    I_asu = np.zeros(q_grid.shape[0])
+    for asu in range(model.xyz.shape[0]):
+        I_asu[mask] += np.square(np.abs(structure_factors(q_grid[mask],
+                                                          model.xyz[asu],
+                                                          model.ff_a[asu], 
+                                                          model.ff_b[asu], 
+                                                          model.ff_c[asu], 
+                                                          U=U, 
+                                                          batch_size=batch_size)))
+        
+    # get symmetry information for expanded map
+    sym_ops = expand_sym_ops(model.sym_ops)
+    hkl_sym = get_symmetry_equivalents(hkl_grid, sym_ops)
+    ravel, map_shape_ravel = get_ravel_indices(hkl_sym, sampling)
+    sampling_ravel = get_centered_sampling(map_shape_ravel, sampling)
+    hkl_grid_mult, mult = compute_multiplicity(model, 
+                                               sampling_ravel[0], 
+                                               sampling_ravel[1], 
+                                               sampling_ravel[2])
+
+    # symmetrize and account for multiplicity
+    I = np.zeros(map_shape_ravel).flatten()
+    I[ravel[0]] = I_asu.copy()
+    for asu in range(1, ravel.shape[0]):
+        I[ravel[asu]] += I_asu.copy()
+    I = I.reshape(map_shape_ravel)
+    I /= (mult.max() / mult) 
+    
+    sampling_original = [(int(hkl_grid[:,i].min()),int(hkl_grid[:,i].max()),sampling[i]) for i in range(3)]
+    I = resize_map(I, sampling_original, sampling_ravel)
+    
+    return I
+    
+def incoherent_sum_reciprocal(model, hkl_grid, sampling, U=None, batch_size=10000):
+    """
+    Compute the incoherent sum of the scattering from all asus.
+    For each grid point, the symmetry-equivalents are determined
+    and mapped from 3d to 1d space by raveling. The intensities 
+    for the first asu are computed and mapped to subsequent asus.
+    Finally, intensities across symmetry-equivalent reflections 
+    are summed (hence in reciprocal rather than real space). The 
+    extents defined by hkl_grid are maintained.
+    
+    Parameters
+    ----------
+    model : AtomicModel
+        instance of AtomicModel class expanded to p1
+    hkl_grid : numpy.ndarray, shape (n_points, 3)
+        hkl vectors of map grid points
+    sampling : tuple
+        sampling frequency along h,k,l axes
+    U : numpy.ndarray, shape (n_atoms,)
+        isotropic displacement parameters, applied to each asymmetric unit
+    batch_size : int
+        number of q-vectors to evaluate per batch
+        
+    Returns
+    -------
+    I : numpy.ndarray, (n_points,)
+        intensity map of the molecular transform
+    """
     hkl_grid_sym = get_symmetry_equivalents(hkl_grid, model.sym_ops)
-    ravel, map_shape_ravel = get_ravel_indices(hkl_grid_sym, (hsampling[2], ksampling[2], lsampling[2]))
+    ravel, map_shape_ravel = get_ravel_indices(hkl_grid_sym, sampling)
     
     I_sym = np.zeros(ravel.shape)
     for asu in range(I_sym.shape[0]):
@@ -161,7 +231,7 @@ def incoherent_from_reciprocal(model, hsampling, ksampling, lsampling, U=None, b
                                                                    model.ff_c[0],
                                                                    U=U,
                                                                    batch_size=batch_size)))
-    I = np.sum(I_sym, axis=0).reshape(map_shape)
+    I = np.sum(I_sym, axis=0)
     return I
 
 class TranslationalDisorder:
@@ -172,7 +242,7 @@ class TranslationalDisorder:
         self.lsampling = lsampling
         self._setup(pdb_path, expand_p1, batch_size)
         
-    def _setup(self, pdb_path, expand_p1=True, batch_size=10000):
+    def _setup(self, pdb_path, expand_p1=True, batch_size=10000, expand_friedel=True, res_limit=0):
         """
         Set up class, including computing the molecular transform.
         
@@ -180,17 +250,21 @@ class TranslationalDisorder:
         ----------
         pdb_path : str
             path to coordinates file of asymmetric unit
-        expand_p1 : bool
-            if True, expand to p1 (i.e. if PDB corresponds to the asymmetric unit)
+        expand_friedel : bool
+            if True, expand to include portion of reciprocal space related by Friedel's law
         batch_size : int
             number of q-vectors to evaluate per batch
+        res_limit : float
+            high resolution limit
         """
         self.q_grid, self.transform = compute_molecular_transform(pdb_path, 
                                                                   self.hsampling, 
                                                                   self.ksampling, 
                                                                   self.lsampling,
                                                                   batch_size=batch_size,
-                                                                  expand_p1=expand_p1)
+                                                                  expand_friedel=expand_friedel,
+                                                                  res_limit=res_limit)
+        self.transform[self.transform==0] = np.nan # compute_cc expects masked values to be np.nan
         self.q_mags = np.linalg.norm(self.q_grid, axis=1)
         self.map_shape = self.transform.shape
     

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -137,7 +137,7 @@ def incoherent_from_reciprocal(model, hsampling, ksampling, lsampling, U=None, b
     """
     hkl_grid, map_shape = generate_grid(model.A_inv, hsampling, ksampling, lsampling, return_hkl=True)
     hkl_grid_sym = get_symmetry_equivalents(hkl_grid, model.sym_ops)
-    ravel = get_ravel_indices(hkl_grid_sym, (hsampling[2], ksampling[2], lsampling[2]))
+    ravel, map_shape_ravel = get_ravel_indices(hkl_grid_sym, (hsampling[2], ksampling[2], lsampling[2]))
     
     I_sym = np.zeros(ravel.shape)
     for asu in range(I_sym.shape[0]):

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -236,13 +236,13 @@ def incoherent_sum_reciprocal(model, hkl_grid, sampling, U=None, batch_size=1000
 
 class TranslationalDisorder:
     
-    def __init__(self, pdb_path, hsampling, ksampling, lsampling, batch_size=10000, expand_p1=True):
+    def __init__(self, pdb_path, hsampling, ksampling, lsampling, batch_size=10000, expand_friedel=True, res_limit=0):
         self.hsampling = hsampling
         self.ksampling = ksampling
         self.lsampling = lsampling
-        self._setup(pdb_path, expand_p1, batch_size)
+        self._setup(pdb_path, batch_size, expand_friedel, res_limit)
         
-    def _setup(self, pdb_path, expand_p1=True, batch_size=10000, expand_friedel=True, res_limit=0):
+    def _setup(self, pdb_path, batch_size=10000, expand_friedel=True, res_limit=0):
         """
         Set up class, including computing the molecular transform.
         

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -15,10 +15,11 @@ def visualize_central_slices(I, vmax_scale=5):
     """
     f, (ax1,ax2,ax3) = plt.subplots(1, 3, figsize=(12,4))
     map_shape = I.shape
+    vmax = I[~np.isnan(I)].mean()*vmax_scale
     
-    ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=I.mean()*vmax_scale)
-    ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=I.mean()*vmax_scale)
-    ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=I.mean()*vmax_scale)
+    ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=vmax)
+    ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=vmax)
+    ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=vmax)
 
     ax1.set_aspect(map_shape[2]/map_shape[1])
     ax2.set_aspect(map_shape[2]/map_shape[0])

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,35 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from eryx.pdb import AtomicModel
+
+def setup_model(case, expand_p1=False):
+    """ Return variables for a test case in the given space group. """
+    
+    if case == 'orthorhombic':
+        hsampling = (-5,5,3)
+        ksampling = (-13,13,2)
+        lsampling = (-20,20,2)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/5zck.pdb"
+
+    elif case == 'trigonal':
+        hsampling = (-18,18,2)
+        ksampling = (-18,18,2)
+        lsampling = (-5,5,3)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/7n2h.pdb"
+
+    elif case == 'triclinic':
+        hsampling = (-14, 14, 2)
+        ksampling = (-5, 5, 2)
+        lsampling = (-15, 15, 2)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/2ol9.pdb"
+        
+    elif case == 'tetragonal':
+        hsampling = (-10, 10, 1)
+        ksampling = (-10, 10, 1)
+        lsampling = (-6, 6, 2)
+        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/193l.pdb"   
+        
+    model = AtomicModel(pdb_path, expand_p1=expand_p1)
+    return pdb_path, model, hsampling, ksampling, lsampling

--- a/tests/test_map_utils.py
+++ b/tests/test_map_utils.py
@@ -6,45 +6,13 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from eryx.pdb import AtomicModel
 import eryx.map_utils as map_utils
-
-def setup_model(case):
-    """ Return variables for a test case in the given space group. """
-    
-    if case == 'orthorhombic':
-        hsampling = (-5,5,3)
-        ksampling = (-17,17,2)
-        lsampling = (-30,30,2)
-        pdb_path = "pdbs/5zck.pdb"
-
-    elif case == 'trigonal':
-        hsampling = (-27,27,2)
-        ksampling = (-27,27,2)
-        lsampling = (-5,5,3)
-        pdb_path = "pdbs/7n2h.pdb"
-
-    elif case == 'triclinic':
-        hsampling = (-14, 14, 2)
-        ksampling = (-5, 5, 2)
-        lsampling = (-15, 15, 2)
-        pdb_path = "pdbs/2ol9.pdb"
-        
-    elif case == 'tetragonal':
-        hsampling = (-30, 30, 2)
-        ksampling = (-30, 30, 2)
-        lsampling = (-16, 16, 2)
-        pdb_path = "pdbs/193l.pdb"   
-
-    else:
-        raise ValueError("Currently only orthorhombic, trigonal, and triclinic are supported.")
-    
-    model = AtomicModel(pdb_path, expand_p1=False)
-    return model, hsampling, ksampling, lsampling
+from base import setup_model
 
 def test_compute_multiplicity():
     """ Test that the correct multiplicity values are assigned to hkl indices. """
 
     for case in ['orthorhombic', 'triclinic']:
-        model, hsampling, ksampling, lsampling = setup_model(case)
+        pdb_path, model, hsampling, ksampling, lsampling = setup_model(case)
         hkl_grid, multiplicity = map_utils.compute_multiplicity(model, hsampling, ksampling, lsampling)
         zeros = 3 - np.count_nonzero(hkl_grid, axis=1)
         
@@ -60,7 +28,7 @@ def test_get_asu_mask():
     """ Test that reflections belonging to the asymmetric unit are correctly identified. """
 
     for case in ['orthorhombic', 'triclinic', 'orthorhombic', 'trigonal']:
-        model, hsampling, ksampling, lsampling = setup_model(case)
+        pdb_path, model, hsampling, ksampling, lsampling = setup_model(case)
         hkl_grid, map_shape = map_utils.generate_grid(model.A_inv, (-1,1,1), (-1,1,1), (-1,1,1), return_hkl=True)
         mask = map_utils.get_asu_mask(model.space_group, hkl_grid)
         hkl_asu = hkl_grid[mask].astype(int)
@@ -71,7 +39,9 @@ def test_get_asu_mask():
 def test_get_dq_map():
     """ Check that the unique dq match their expected values. """
     for case in ['orthorhombic', 'tetragonal']:
-        model, hsampling, ksampling, lsampling = setup_model(case)
+        pdb_path, model, hsampling, ksampling, lsampling = setup_model(case)
+        if case == 'tetragonal':
+            hsampling, ksampling = (-30, 30, 2), (-30, 30, 2) # can't have integral sampling
         hkl_grid, map_shape = map_utils.generate_grid(model.A_inv, hsampling, ksampling, lsampling, return_hkl=True)
         dq_calc = np.unique(map_utils.get_dq_map(model.A_inv, hkl_grid))
         dq_exp = 2*np.pi*np.linalg.norm(model.A_inv.T, axis=0) 


### PR DESCRIPTION
The molecular transform calculation was overhauled to enable including a resolution mask. For the speedier calculation, use the setting `expand_friedel=True`. Associated helper functions to map_utils.py and unit tests were added as well.