### PR TITLE
Mostly multiprocessing, some other changes as well

### DIFF
--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -340,7 +340,7 @@ def get_centered_sampling(map_shape, sampling):
     list of tuples, [hsampling, lsampling, ksampling]
         in which each tuple corresponds to (min, max, fractional sampling rate)
     """
-    extents = [int((map_shape[i]-1) / sampling[i] / 2.0) for i in range(3)]
+    extents = [((map_shape[i]-1) / sampling[i] / 2.0) for i in range(3)]
     return [(-extents[i], extents[i], sampling[i]) for i in range(3)]
 
 def resize_map(new_map, old_sampling, new_sampling):
@@ -362,13 +362,14 @@ def resize_map(new_map, old_sampling, new_sampling):
     new_map : numpy.ndarray, 3d
         potentially cropped map
     """
-    if new_sampling[0][1] != old_sampling[0][1]:
-        excise = 2*(new_sampling[0][1] - old_sampling[0][1])
+    tol = 1e-6
+    if np.abs(new_sampling[0][1] - old_sampling[0][1]) > tol:
+        excise = int(np.around(2*(new_sampling[0][1] - old_sampling[0][1])))
         new_map = new_map[excise:-excise,:,:]
-    if new_sampling[1][1] != old_sampling[1][1]:
-        excise = 2*(new_sampling[1][1] - old_sampling[1][1])
+    if np.abs(new_sampling[1][1] - old_sampling[1][1]) > tol:
+        excise = int(np.around(2*(new_sampling[1][1] - old_sampling[1][1])))
         new_map = new_map[:,excise:-excise,:]
-    if new_sampling[2][1] != old_sampling[2][1]:
-        excise = 2*(new_sampling[2][1] - old_sampling[2][1])
+    if np.abs(new_sampling[2][1] - old_sampling[2][1]) > tol:
+        excise = int(np.around(2*(new_sampling[2][1] - old_sampling[2][1])))
         new_map = new_map[:,:,excise:-excise]
     return new_map

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 plotly
 scipy
 tqdm
+multiprocessing

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,8 +118,8 @@ class TestLiquidLikeMotions:
     Check liquid like motions model.
     """
     def setup_class(cls):
-        cls.pdb_path = "pdbs/histidine.pdb"
-        cls.model = LiquidLikeMotions(cls.pdb_path, (-13,13,2), (-13,13,2), (-13,13,2), expand_p1=True)
+        cls.pdb_path = "pdbs/5zck.pdb"
+        cls.model = LiquidLikeMotions(cls.pdb_path, (-5,5,2), (-13,13,2), (-20,20,2), expand_p1=True)
 
     def test_dilate(self):
         """ Check that map was correctly dilated: q_mags should match. """

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -32,10 +32,12 @@ class TestScatter(object):
     def test_structure_factors(self):
         """ Check that accelerated structure factors calculation is correct. """
         U = np.random.randn(self.model.xyz.shape[0])
-        sf = scatter.structure_factors(self.q_grid, self.model.xyz, self.model.ff_a, self.model.ff_b, self.model.ff_c, U)
+        sf_np8 = scatter.structure_factors(self.q_grid, self.model.xyz, self.model.ff_a, self.model.ff_b, self.model.ff_c, U)
+        sf_np1 = scatter.structure_factors(self.q_grid, self.model.xyz, self.model.ff_a, self.model.ff_b, self.model.ff_c, U, n_processes=1)
         sf_ref = reference.structure_factors(self.q_grid, self.model.xyz, self.model.elements, U)
-        assert np.allclose(np.square(np.abs(sf)), np.square(np.abs(sf_ref)))
-
+        assert np.allclose(np.square(np.abs(sf_np8)), np.square(np.abs(sf_ref)))
+        assert np.allclose(np.square(np.abs(sf_np1)), np.square(np.abs(sf_ref)))
+        
     def test_structure_factors_vs_gemmi(self):
         """ Check that structure factors calculation matches gemmi. """
         hkl = np.random.randint(-10, high=10, size=3)

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -16,7 +16,7 @@ class TestScatter(object):
     @classmethod
     def setup_class(cls):
         cls.pdb_path = "pdbs/histidine_p1.pdb"
-        cls.model = AtomicModel(cls.pdb_path)
+        cls.model = AtomicModel(cls.pdb_path, clean_pdb=False)
         cls.model.flatten_model()
         cls.q_grid, cls.map_shape = map_utils.generate_grid(cls.model.A_inv, (-2,2,5), (-2,2,5), (-2,2,5))
         


### PR DESCRIPTION
Updates include:
- optional use of multiprocessing to parallelize the structure factor calculation.
- in computing the molecular transform, if the space group is P 1 and `expand_friedel=False`, the reference calculation is used (rather than either of the symmetrization approaches) to not waste time on determining the symmetry mappings when there aren't any.
- fixes to the functions in map_utils.py that were failing when the edge voxels of the maps weren't integral Miller indices
- the `clean_pdb` function broke unit tests that relied on the histidine PDB (because it's all HETATMs); these have been fixed.