### PR TITLE
`RotationalDisorder` udpate

### DIFF
--- a/eryx/stats.py
+++ b/eryx/stats.py
@@ -103,7 +103,7 @@ def compute_cc_by_dq(arr1, arr2, dq_map, mask=None):
     """
     arr1, arr2 = arr1.flatten(), arr2.flatten()
     if mask is None:
-        mask = np.ones(res_map.shape).astype(bool)
+        mask = np.ones(dq_map.shape).astype(bool)
     mask *= ~np.isnan(np.sum(np.vstack((arr1, arr2)), axis=0))
     
     dq_vals = np.unique(dq_map)


### PR DESCRIPTION
The `RotationalDisorder` class was updated to accept `res_limit` and `n_processes` arguments during instantiation to accelerate the calculation by limiting the resolution and parallelization, respectively. A fix was also made to the `get_dq_map` function, which was erroneously calling an undefined variable.