### PR TITLE
omitting multiprocessing from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ numpy
 plotly
 scipy
 tqdm
-multiprocessing


### PR DESCRIPTION
Since this comes natively with Python (and `pip install` seems to grab the wrong version)