### PR TITLE
LLM overhaul

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -39,7 +39,7 @@ def compute_crystal_transform(pdb_path, hsampling, ksampling, lsampling, U=None,
     q_grid : numpy.ndarray, (n_points, 3)
         q-vectors corresponding to flattened intensity map
     I : numpy.ndarray, 3d
-        intensity map of the crystal transform, np.nan 
+        intensity map of the crystal transform
     """
     model = AtomicModel(pdb_path, expand_p1=expand_p1, frame=-1)
     model.flatten_model()
@@ -60,8 +60,6 @@ def compute_crystal_transform(pdb_path, hsampling, ksampling, lsampling, U=None,
                                                  U=U, 
                                                  batch_size=batch_size,
                                                  n_processes=n_processes)))
-    I[~mask] = np.nan
-    
     return q_grid, I.reshape(map_shape)
 
 def compute_molecular_transform(pdb_path, hsampling, ksampling, lsampling, U=None, expand_p1=True,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -121,14 +121,6 @@ class TestLiquidLikeMotions:
         cls.pdb_path = "pdbs/5zck.pdb"
         cls.model = LiquidLikeMotions(cls.pdb_path, (-5,5,2), (-13,13,2), (-20,20,2), expand_p1=True)
 
-    def test_dilate(self):
-        """ Check that map was correctly dilated: q_mags should match. """
-        q_mags_int = np.linalg.norm(self.model.q_grid_int, axis=1).reshape(self.model.map_shape_int)
-        q_mags_int = self.model._dilate(q_mags_int, (self.model.hsampling[2], self.model.ksampling[2], self.model.lsampling[2]))
-        q_mags_frac = self.model.q_mags.copy().reshape(self.model.map_shape)
-        q_mags_frac[q_mags_int==0] = 0
-        assert np.allclose(q_mags_frac, q_mags_int)
-
     def test_mask(self):
         """ Check that mask is only applied to out-of-bounds q-vectors. """
         q_grid, map_shape = generate_grid(AtomicModel(self.pdb_path).A_inv,


### PR DESCRIPTION
Specifically:
1. the crystal transform now accepts fractional sampling and only calculates the intensity for integral Miller indices.
2. the LLM has an argument to set the number of processes for the crystal transform calculation.
3. we no longer dilate the transform because of the changes described in 1.
4. q-grid points outside an optional high-resolution limit are masked.
5. if the map size exceeds a certain threshold (10 billion q-vectors), we do the convolution ourselves rather than relying on scipy.signal.fftconvolve to avoid memory errors.