### PR TITLE
`NonInteractingDeformableMolecules` disorder model and `Crystal` tools

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.signal
 import scipy.spatial
-from .pdb import AtomicModel
+from .pdb import AtomicModel, GaussianNetworkModel
 from .map_utils import *
 from .scatter import structure_factors
 from .stats import compute_cc
@@ -805,4 +805,168 @@ class EnsembleDisorder:
             for nm in range(n_maps):
                 Id[nm] += fc_square[nm] - np.square(np.abs(fc[nm]))
                 
+        return Id
+
+class NonInteractingDeformableMolecules:
+
+    """
+    Lattice model with non-interacting deformable molecules.
+    Each asymmetric unit is a Gaussian Network Model.
+    """
+
+    def __init__(self, pdb_path, hsampling, ksampling, lsampling,
+                 expand_p1=True, res_limit=0, gnm_cutoff=4.,
+                 batch_size=10000, n_processes=8):
+        self.hsampling = hsampling
+        self.ksampling = ksampling
+        self.lsampling = lsampling
+        self.batch_size = batch_size
+        self.n_processes = n_processes
+        self._setup(pdb_path, expand_p1, res_limit)
+        self._setup_gnm(pdb_path, gnm_cutoff)
+
+    def _setup(self, pdb_path, expand_p1, res_limit, q2_rounding=3):
+        """
+        Compute q-vectors to evaluate.
+
+        Parameters
+        ----------
+        pdb_path : str
+            path to coordinates file of asymmetric unit
+        res_limit : float
+            high-resolution limit in Angstrom
+        q2_rounding : int
+            number of decimals to round q squared to, default: 3
+        """
+        self.model = AtomicModel(pdb_path, expand_p1=expand_p1)
+
+        hkl_grid, self.map_shape = generate_grid(self.model.A_inv,
+                                                 self.hsampling,
+                                                 self.ksampling,
+                                                 self.lsampling,
+                                                 return_hkl=True)
+        self.res_mask, res_map = get_resolution_mask(self.model.cell,
+                                                     hkl_grid,
+                                                     res_limit)
+        self.q_grid = 2 * np.pi * np.inner(self.model.A_inv.T, hkl_grid).T
+
+        q2 = np.linalg.norm(self.q_grid, axis=1) ** 2
+        self.q2_unique, \
+        self.q2_unique_inverse = np.unique(np.round(q2, q2_rounding),
+                                           return_inverse=True)
+
+    def _setup_gnm(self, pdb_path, gnm_cutoff):
+        """
+        Build Gaussian Network Model.
+
+        Parameters
+        ----------
+        pdb_path : str
+            path to coordinates file of asymmetric unit
+        gnm_cutoff : float
+            distance cutoff used to define atom pairs
+        """
+        self.gnm = GaussianNetworkModel(pdb_path,
+                                        enm_cutoff=gnm_cutoff,
+                                        gamma_intra=1.,
+                                        gamma_inter=0.)
+
+    def compute_covariance_matrix(self):
+        """
+        Compute covariance matrix for one asymmetric unit.
+        The covariance matrix results from modelling pairwise
+        interactions with a Gaussian Network Model where atom
+        pairs belonging to different asymmetric units are not
+        interacting. It is scaled to match the ADPs in the input PDB file.
+        """
+        Kinv = self.gnm.compute_Kinv(self.gnm.compute_hessian())
+        Kinv = np.real(Kinv[0, :, 0, :])  # only need that
+        ADP_scale = np.mean(self.model.adp[0]) / \
+                    (8 * np.pi * np.pi * np.mean(np.diag(Kinv)) / 3.)
+        self.covar = Kinv * ADP_scale
+        self.ADP = np.diag(self.covar)
+
+    def _low_rank_truncation(self, sym_matrix, rank=None, rec_error_threshold=0.01):
+        """
+        Perform low rank approximation of a symmetric matrix.
+        Either the desired rank is provided, or it is found
+        when the reconstructed matrix Froebenius norm is the
+        same as the original matrix, up to a provided
+        reconstruction error.
+
+        Parameters
+        ----------
+        sym_matrix : numpy.ndarray, shape (n, n)
+            must be a 2D symmetric array
+        rank : int or None
+            if not None, the desired rank
+        rec_error_threshold : float
+            if rank is None, the maximal reconstruction error
+        Returns
+        -------
+        u : numpy.ndarray, shape (n, rank)
+            First rank-th components of sym_matrix
+        s : numpy.ndarray, shape (rank,)
+            First rank-th singular values of sym_matrix
+        """
+        u, s, vh = np.linalg.svd(sym_matrix)
+        if rank is None:
+            sym_matrix_norm = np.linalg.norm(sym_matrix)
+            for rank in range(s.shape[0]):
+                rec_matrix = (u[:, :rank] * s[:rank]) @ vh[:rank, :]
+                rec_matrix_norm = np.linalg.norm(rec_matrix)
+                rec_error = 1. - rec_matrix_norm / sym_matrix_norm
+                if rec_error < rec_error_threshold:
+                    break
+        return u[:, :rank], s[:rank]
+
+    def compute_scl_intensity(self):
+        """
+        Compute diffuse intensity of non-interacting deformable
+        molecules, in the soft-coupling limit.
+        Namely, given a Gaussian Network Model (GNM) for the
+        asymmetric unit (ASU), the covariance C is factorized:
+        C = B * D @ B.T and eventually low-rank truncated.
+        The diffuse intensity is then the incoherent sum over
+        its components, weighted by q**2, where we introduce
+        the component factors G = F * B:
+        I(q) = q**2 \sum_r D_r \sum_asu |G_asu,r|**2
+        """
+        Id = np.zeros((self.q_grid.shape[0]))
+        self.compute_covariance_matrix()
+        u, s = self._low_rank_truncation(self.covar)
+        for i_asu in range(self.model.n_asu):
+            Id += np.dot(np.square(np.abs(structure_factors(self.q_grid,
+                                                           self.model.xyz[i_asu],
+                                                           self.model.ff_a[i_asu],
+                                                           self.model.ff_b[i_asu],
+                                                           self.model.ff_c[i_asu],
+                                                           U=self.ADP,
+                                                           batch_size=self.batch_size,
+                                                           n_processes=self.n_processes,
+                                                           project_on_components=u,
+                                                           sum_over_atoms=False))), s)
+        return np.multiply(self.q2_unique[self.q2_unique_inverse], Id)
+
+    def apply_disorder(self, scl=True):
+        """
+        Compute diffuse intensity of non-interacting deformable
+        molecules.
+        Namely, given a Gaussian Network Model (GNM) for the
+        asymmetric unit (ASU), the covariance C between atomic
+        displacements is computed. Then the coupling between
+        structure factors F can be defined as J = exp(q2*C) - 1.
+        The diffuse intensity is then the incoherent sum over
+        asymmetric units: Id = \sum_asu F_asu.T J F_asu.
+        Because computing this in the general case would not
+        scale well, several approximations/simplifications are
+        offered (at the moment, only the soft-coupling limit).
+
+        Parameters
+        ----------
+        scl : bool
+            whether we are in the soft-coupling limit or not.
+        """
+        if scl:
+            Id = self.compute_scl_intensity()
         return Id

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -81,7 +81,7 @@ class VisualizeCrystal:
         showlegend : bool, default: False
             Whether the object appears in the legend or not.
         """
-        u_xyz = self.model.unit_cell_axes
+        u_xyz = self.crystal.model.unit_cell_axes
         p_xyz = np.zeros((16, 3))
         p_sign_sequence = [1, 1, -1, 1, 1, -1, -1, 1, -1, -1, 1, 1, -1, 1, 1]
         p_id_sequence = [2, 1, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 1, 2, 1]
@@ -164,4 +164,4 @@ class VisualizeCrystal:
         else:
             color_dict = mcolors.CSS4_COLORS
         color_array = np.array(list(color_dict.items()))
-        return color_array[::color_array.shape[0]/ndx,1][idx]
+        return color_array[::color_array.shape[0]//ndx,1][idx]

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -1,5 +1,7 @@
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 import numpy as np
+import plotly.graph_objects as go
 
 def visualize_central_slices(I, vmax_scale=5):
     """
@@ -32,3 +34,134 @@ def visualize_central_slices(I, vmax_scale=5):
     for ax in [ax1,ax2,ax3]:
         ax.set_xticks([])
         ax.set_yticks([])
+
+
+class VisualizeCrystal:
+
+    def __init__(self, crystal):
+        """
+        Plotly helper functions to visualize the Crystal object.
+        Parameters
+        ----------
+        crystal : eryx.models.Crystal object
+        """
+        self.crystal = crystal
+        self.draw_data = None
+        self.color_by = 'asu_id'
+        self.color_palette = 'xkcd'
+
+    def show(self):
+        """
+        Show the crystal's supercell in a plotly figure.
+        """
+        self.draw_supercell()
+        self.fig.show()
+
+    def draw_supercell(self):
+        """
+        For every cell in the crystal' supercell,
+        draw its cell axes and the asymmetric units it contains.
+        """
+        for h in self.crystal.xrange:
+            for k in self.crystal.yrange:
+                for l in self.crystal.zrange:
+                    self.draw_unit_cell_axes(origin=self.crystal.get_unitcell_origin(unit_cell=[h,k,l]))
+                    for i_asu in np.arange(self.crystal.model.n_asu):
+                        self.draw_asu(i_asu, unit_cell=[h,k,l],
+                                      name=f'Cell #{self.crystal._hkl_to_id(unit_cell=[h,k,l])} | ASU #{i_asu}')
+
+    def draw_unit_cell_axes(self, origin=np.array([0., 0., 0.]), showlegend=False):
+        """
+        Draw the axes of a cell as a Scatter3D plotly object.
+
+        Parameters
+        ----------
+        origin : numpy.ndarray, shape (3,), default: np.array([0.,0.,0.])
+            3d coordinate of the unit cell origin.
+        showlegend : bool, default: False
+            Whether the object appears in the legend or not.
+        """
+        u_xyz = self.model.unit_cell_axes
+        p_xyz = np.zeros((16, 3))
+        p_sign_sequence = [1, 1, -1, 1, 1, -1, -1, 1, -1, -1, 1, 1, -1, 1, 1]
+        p_id_sequence = [2, 1, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 1, 2, 1]
+        p_xyz[0] = origin
+        for i in range(15):
+            p_xyz[i + 1] = p_xyz[i] + p_sign_sequence[i] * u_xyz[p_id_sequence[i]]
+        self._draw_go_vector(self._build_go_vector(p_xyz,
+                                                   line=dict(color="gray", width=1),
+                                                   showlegend=showlegend))
+
+    def draw_asu(self, asu_id=0, unit_cell=None, name='asu0', showlegend=True):
+        """
+        Draw an asymmetric unit as a Scatter3d plotly object.
+
+        Parameters
+        ----------
+        asu_id : asymmetric unit index
+        unit_cell : list of 3 integer indices.
+            Index of the unit cell along the 3 dimensions.
+        name : string, default: 'asu0'
+            Name displayed in legend.
+        showlegend : bool, default: True
+            Whether the object appears in the legend or not
+        """
+        if unit_cell is None:
+            unit_cell = [0, 0, 0]
+        self._draw_go_vector(self._build_go_vector(self.crystal.get_asu_xyz(asu_id, unit_cell),
+                                                   mode='markers',
+                                                   marker=dict(size=5,
+                                                               color=self._get_color(asu_id, unit_cell)),
+                                                   name=name,
+                                                   showlegend=showlegend))
+
+    def _draw_go_vector(self, go_vector):
+        if self.draw_data is None:
+            self.draw_data = [go_vector]
+        else:
+            self.draw_data.append(go_vector)
+        self.fig = go.Figure(data=self.draw_data)
+
+    def _build_go_vector(self, xyz, mode='lines', line=None, marker=None,
+                         name=None, showlegend=True):
+        if line is None:
+            line = {}
+        if marker is None:
+            marker = {}
+        return go.Scatter3d(x=xyz[:, 0],
+                            y=xyz[:, 1],
+                            z=xyz[:, 2],
+                            mode=mode,
+                            line=line,
+                            marker=marker,
+                            name=name,
+                            showlegend=showlegend)
+
+    def _get_color(self, asu_id, unit_cell=None):
+        """
+        Return the ASU color.
+
+        Parameters
+        ----------
+        asu_id : asymmetric unit index
+        unit_cell : list of 3 integer indices.
+            Index of the unit cell along the 3 dimensions.
+        """
+        if unit_cell is None:
+            unit_cell = [0, 0, 0]
+        idx = 0
+        ndx = 1
+        if self.color_by == 'asu_id':
+            idx = asu_id
+            ndx = self.crystal.model.n_asu
+        elif self.color_by == 'unit_cell':
+            idx = self.crystal._hkl_to_id(unit_cell)
+            ndx = self.crystal.n_cell
+        if self.color_palette == 'xkcd':
+            color_dict = mcolors.XKCD_COLORS
+        elif self.color_palette == 'tableau':
+            color_dict = mcolors.TABLEAU_COLORS
+        else:
+            color_dict = mcolors.CSS4_COLORS
+        color_array = np.array(list(color_dict.items()))
+        return color_array[::color_array.shape[0]/ndx,1][idx]

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -68,7 +68,7 @@ class VisualizeCrystal:
                     self.draw_unit_cell_axes(origin=self.crystal.get_unitcell_origin(unit_cell=[h,k,l]))
                     for i_asu in np.arange(self.crystal.model.n_asu):
                         self.draw_asu(i_asu, unit_cell=[h,k,l],
-                                      name=f'Cell #{self.crystal._hkl_to_id(unit_cell=[h,k,l])} | ASU #{i_asu}')
+                                      name=f'Cell #{self.crystal.hkl_to_id(unit_cell=[h,k,l])} | ASU #{i_asu}')
 
     def draw_unit_cell_axes(self, origin=np.array([0., 0., 0.]), showlegend=False):
         """
@@ -155,7 +155,7 @@ class VisualizeCrystal:
             idx = asu_id
             ndx = self.crystal.model.n_asu
         elif self.color_by == 'unit_cell':
-            idx = self.crystal._hkl_to_id(unit_cell)
+            idx = self.crystal.hkl_to_id(unit_cell)
             ndx = self.crystal.n_cell
         if self.color_palette == 'xkcd':
             color_dict = mcolors.XKCD_COLORS


### PR DESCRIPTION
The new `NonInteractingDeformableMolecules` (NIDM) model was added. It depends on the `GaussianNetworkModel` class newly added too, which in turn depends on the newly added `Crystal` object (to build the neighbor unit cells around the reference unit cell, mainly). Helper visualization tools were created for the latter.

At the moment, only the "soft-coupling limit" of the NIDM model has been implemented. 

The intended usage is as follows:
```python
from eryx.pdb import AtomicModel, Crystal
from eryx.visuals import VisualizeCrystal
from eryx.models import NonInteractingDeformableMolecules as NIDM

pdb_path='../tests/pdbs/6o2h_clean.pdb'

model = AtomicModel(pdb_path, expand_p1=True)

crystal = Crystal(model)
crystal.supercell_extent(nx=1, ny=1, nz=1)

visualize_crystal = VisualizeCrystal(crystal)
visualize_crystal.color_by = 'unit_cell'
visualize_crystal.show()
```

Resulting in an interactive `plotly` figure:
![image](https://user-images.githubusercontent.com/4610338/213897289-1916368a-5169-46f3-b7ae-28119bb98987.png)

```python
hsampling, ksampling, lsampling = ((-13,13,5),(-16,16,5),(-17,17,5))
nidm = NIDM(pdb_path, hsampling, ksampling, lsampling)
Id_nidm = nidm.apply_disorder()
visualize_central_slices(np.real(Id_nidm).reshape(nidm.map_shape), vmax_scale=11
```
![output](https://user-images.githubusercontent.com/4610338/213897327-d8b4ad4e-dff0-40f9-8767-de94b5b46c15.png)

To explore a little bit under the hood, one can interactively plot the covariance matrix:
```python
import plotly.express as px
import plotly.io as pio
pio.renderers.default = 'browser'
fig = px.imshow(nidm.covar)
fig.show()
```
![image](https://user-images.githubusercontent.com/4610338/213897448-26e289e1-96a7-4cc6-8d52-a434c4cdcdd0.png)

or just the modelled Atomic Displacement Parameters:
```python
fig = px.scatter(nidm.ADP)
fig.show()
```
![Screen Shot 2023-01-21 at 6 10 12 PM](https://user-images.githubusercontent.com/4610338/213897813-a5498464-b27c-4e88-aa48-9b5a7180f667.png)



*Note: unit tests to follow hopefully soon*