### PR TITLE
Grab bag

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -639,7 +639,7 @@ class RotationalDisorder:
         rot_mat = scipy.spatial.transform.Rotation.from_rotvec(rot_vec).as_matrix()
         return rot_mat
     
-    def apply_disorder(self, sigmas, num_rot=100):
+    def apply_disorder(self, sigmas, num_rot=100, sf_out=None):
         """
         Compute the diffuse maps(s) resulting from rotational disorder for 
         the given sigmas by applying Guinier's equation to an ensemble of 
@@ -652,7 +652,9 @@ class RotationalDisorder:
             standard deviation(s) of angular sampling in degrees
         num_rot : int
             number of rotations to generate per sigma
-        
+        sf_out : str
+            save select (unmasked) structure factor amplitudes to given path
+
         Returns
         -------
         Id : numpy.ndarray, (n_sigma, q_grid.shape[0])
@@ -682,6 +684,9 @@ class RotationalDisorder:
                                           U=None, 
                                           batch_size=self.batch_size,
                                           n_processes=self.n_processes)
+                    if sf_out is not None:
+                        np.save(sf_out, A)
+                        return
                     fc[self.mask] += A
                     fc_square[self.mask] += np.square(np.abs(A)) 
                 Id[n_sigma] += fc_square / num_rot - np.square(np.abs(fc / num_rot))

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,25 +11,25 @@ def setup_model(case, expand_p1=False):
         hsampling = (-5,5,3)
         ksampling = (-13,13,2)
         lsampling = (-20,20,2)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/5zck.pdb"
+        pdb_path = "pdbs/5zck.pdb"
 
     elif case == 'trigonal':
         hsampling = (-18,18,2)
         ksampling = (-18,18,2)
         lsampling = (-5,5,3)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/7n2h.pdb"
+        pdb_path = "pdbs/7n2h.pdb"
 
     elif case == 'triclinic':
         hsampling = (-14, 14, 2)
         ksampling = (-5, 5, 2)
         lsampling = (-15, 15, 2)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/2ol9.pdb"
+        pdb_path = "pdbs/2ol9.pdb"
         
     elif case == 'tetragonal':
         hsampling = (-10, 10, 1)
         ksampling = (-10, 10, 1)
         lsampling = (-6, 6, 2)
-        pdb_path = "/Users/apeck/Desktop/diffuse/eryx/tests/pdbs/193l.pdb"   
+        pdb_path = "pdbs/193l.pdb"   
         
     model = AtomicModel(pdb_path, expand_p1=expand_p1)
     return pdb_path, model, hsampling, ksampling, lsampling


### PR DESCRIPTION
Two changes:
1. removing erroneously hard-coded paths in base.py for unit tests.
2. adding the option to save the structure factors for ensemble members of the `RotationalDisorder` class.