### PR TITLE
Exact implementation of `NonInteractingDeformableMolecules` model

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@ A collection of scripts for simulating diffuse scattering from protein crystals.
 
 To create the `silicx` conda environment:
 > conda create --name sicilx python=3.10
+> 
 > conda activate sicilx
+> 
 > pip install -r requirements.txt

--- a/eryx/map_utils.py
+++ b/eryx/map_utils.py
@@ -136,7 +136,8 @@ def compute_resolution(cell, hkl):
     n2b = 2.0*l*h*(np.cos(gamma)*np.cos(alpha) - np.cos(beta))/(c*a)
     n2c = 2.0*h*k*(np.cos(alpha)*np.cos(beta) - np.cos(gamma))/(a*b)
 
-    return 1.0 / np.sqrt((n1 + n2a + n2b + n2c) / pf)
+    with np.errstate(divide='ignore'):
+        return 1.0 / np.sqrt((n1 + n2a + n2b + n2c) / pf)
 
 def get_hkl_extents(cell, resolution, oversampling=1):
     """

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -990,10 +990,10 @@ class NonInteractingDeformableMolecules:
             Jq = np.power(Tmat,
                           self.q2_unique[self.q2_unique_inverse][iq]) - 1.
             for i_asu in range(self.model.n_asu):
-                Id[iq] = np.matmul(F[i_asu,iq],
+                Id[iq] += np.matmul(F[i_asu,iq],
                                    np.matmul(Jq,
                                              np.conj(F[i_asu,iq])))
-        return Id
+        return np.real(Id)
 
     def apply_disorder(self, scl=True):
         """


### PR DESCRIPTION
A follow-up to the implementation of the NIDM model (PR #23) where we add an option to compute the exact intensity. It is not recommended to use it since it will not scale well with anything (number of q points, number of atoms, ...) but might be useful as a reference.