### PR TITLE
LLM scan visualization and class renaming

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -278,7 +278,7 @@ def incoherent_sum_reciprocal(model, hkl_grid, sampling, U=None, batch_size=1000
     I = np.sum(I_sym, axis=0)
     return I
 
-class TranslationalDisorder:
+class RigidBodyTranslations:
     
     def __init__(self, pdb_path, hsampling, ksampling, lsampling, expand_friedel=True, res_limit=0, batch_size=10000, n_processes=8):
         self.hsampling = hsampling
@@ -615,7 +615,7 @@ class LiquidLikeMotions:
         print(f"Optimal sigma: {self.opt_sigma}, optimal gamma: {self.opt_gamma}, with correlation coefficient {ccs[opt_index]:.4f}")
         return ccs, sigmas, gammas
     
-class RotationalDisorder:
+class RigidBodyRotations:
     
     """
     Model of rigid body rotational disorder, in which all atoms in 
@@ -771,7 +771,7 @@ class RotationalDisorder:
         print(f"Optimal sigma: {self.opt_sigma}, with correlation coefficient {ccs[opt_index]:.4f}")
         return ccs, sigmas
     
-class EnsembleDisorder:
+class Ensemble:
     
     """
     Model of ensemble disorder, in which the components of the

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -90,13 +90,13 @@ class TestMolecularTransform:
         hkl, I1 = compute_molecular_transform(pdb_path, hsampling, ksampling, (0,15,2), expand_friedel=True, res_limit=self.dmin[case])
         assert np.max(np.abs(self.Iref[case][I1!=0] -  I1[I1!=0])/I1[I1!=0]) < 1e-2
         
-class TestTranslationalDisorder:
+class TestRigidBodyTranslations:
     """
     Check translational disorder model.
     """
     def setup_class(cls):
         pdb_path = "pdbs/5zck.pdb"
-        cls.model = TranslationalDisorder(pdb_path, (-4,4,1), (-17,17,1), (-29,29,1))
+        cls.model = RigidBodyTranslations(pdb_path, (-4,4,1), (-17,17,1), (-29,29,1))
         
     def test_anisotropic_sigma(self):
         """ Check that maps with the same (an)isotropic sigma match. """
@@ -142,13 +142,13 @@ class TestLiquidLikeMotions:
         assert gammas[np.argmin(np.abs(gammas - g))] == self.model.opt_gamma
         assert sigmas[np.argmin(np.abs(sigmas - s))] == self.model.opt_sigma
 
-class TestRotationalDisorder:
+class TestRigidBodyRotations:
     """
     Check the rotational disorder model.
     """
     def setup_class(cls):
         pdb_path = "pdbs/2ol9.pdb"
-        cls.model = RotationalDisorder(pdb_path, (-14,14,1), (-5,5,1), (-15,15,1))
+        cls.model = RigidBodyRotations(pdb_path, (-14,14,1), (-5,5,1), (-15,15,1))
 
     def test_optimize(self):
         """ Check that optimization identifies the correct sigma. """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -152,7 +152,7 @@ class TestRotationalDisorder:
 
     def test_optimize(self):
         """ Check that optimization identifies the correct sigma. """
-        param = float(np.random.choice(np.linspace(1.0,3.0,3)))
+        param = float(np.random.choice(np.linspace(1.0,5.0,3)))
         target = self.model.apply_disorder(param)[0].reshape(self.model.map_shape)
-        self.model.optimize(target, 1.0, 3.0, n_search=3)
+        self.model.optimize(target, 1.0, 5.0, n_search=3)
         assert self.model.opt_sigma == param


### PR DESCRIPTION
- The rigid body disorder classes were renamed `RigidBodyTranslations` and `RigidBodyRotations`. `EnsembleDisorder` was updated to `Ensemble`.
- Multiple calls of the `optimize` function in the `LiquidLikeMotions` class will result in the sigmas, gammas, and associated overall correlation coefficients to be stored as class variables. These can then be visualized by calling the class's `plot_scan` function, resulting in a plot like the below:
![download-1](https://user-images.githubusercontent.com/6363287/214133283-781e7d17-0707-47b1-9691-a1d6caae43e1.png)
