### PR TITLE
`OnePhonon` visuals and enhancements

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -1301,9 +1301,21 @@ class OnePhonon:
                         Id[q_indices] += np.square(
                             np.abs(np.dot(F, self.V[dh,dk,dl,:,rank]))) * \
                                          self.Winv[dh,dk,dl,:,rank]
-        Id[:, ~self.res_mask] = np.nan
+        Id[~self.res_mask] = np.nan
         Id = np.real(Id)
         if outdir is not None:
             np.save(os.path.join(outdir, f"rank_{rank:05}.npy"), Id)
         return Id
+
+class OnePhononBrillouin:
+
+    def __init__(self, pdb_path, h, k, l, N,
+                 group_by='asu', model='gnm',
+                 gnm_cutoff=4., gamma_intra=1., gamma_inter=1.,
+                 batch_size=10000, n_processes=8):
+        self.phonon = OnePhonon(pdb_path,(h-1,h+1,N),(k-1,k+1,N), (l-1,l+1,N),
+                                group_by=group_by, model=model,
+                                gnm_cutoff=gnm_cutoff, gamma_intra=gamma_intra, gamma_inter=gamma_inter,
+                                batch_size=batch_size, n_processes=n_processes)
+        self.Id = self.phonon.apply_disorder().reshape(self.phonon.map_shape)[N//2+1:-N//2,N//2+1:-N//2,N//2+1:-N//2]
 

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -1235,6 +1235,8 @@ class OnePhonon:
                     v, w, _ = np.linalg.svd(Dmat)
                     w = np.sqrt(w)
                     w = np.where(w < 1e-6, np.nan, w)
+                    w = w[::-1]
+                    v = v[:,::-1]
                     self.Winv[dh, dk, dl] = 1. / w ** 2
                     self.V[dh, dk, dl] = np.matmul(self.Linv.T, v)
 

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -263,7 +263,7 @@ class PhononPlots:
     def dispersion_curve(self):
         nrows = 2
         ncols = 4
-        fig = plt.figure(figsize=(2 * ncols, 2 * nrows), dpi=180,
+        fig = plt.figure(figsize=(2 * ncols, 4 * nrows), dpi=180,
                          constrained_layout=True)
         gs = GridSpec(nrows, ncols, figure=fig)
 
@@ -287,7 +287,7 @@ class PhononPlots:
                 for i in range(wvec.shape[-1]):
                     ax.plot(knorm, wvec[:, i], 'o', label=f'#{i}')
                     if gs_i == 1:
-                        ax.set_xlabel('phonon wavector')
+                        ax.set_xlabel('phonon wavevector ($\mathrm{\AA}^{-1}$)')
                     if gs_j == 0:
                         ax.set_ylabel('phonon frequency')
                 if i_curve == 3:
@@ -303,7 +303,7 @@ class PhononPlots:
     def contribution_curve(self):
         nrows=2
         ncols=3
-        fig = plt.figure(figsize=(2 * ncols, 2 * nrows), dpi=180,
+        fig = plt.figure(figsize=(2 * ncols, 3 * nrows), dpi=180,
                          constrained_layout=True)
         gs = GridSpec(nrows, ncols, figure=fig)
         knorm = self.phonon.kvec_norm.reshape(-1,1)
@@ -325,10 +325,10 @@ class PhononPlots:
                         '.', label=f'{A[i]}')
             ax.set_title(f'#{i_curve}')
             if gs_i == 1:
-                ax.set_xlabel('phonon wavector')
+                ax.set_xlabel('phonon wavevector ($\mathrm{\AA}^{-1}$)')
             if gs_j == 0:
                 ax.set_ylabel('phonon intensity')
             ax.set_yscale('log')
-            if i_curve == 0:
-                ax.legend()
+            if i_curve == 2:
+                ax.legend(bbox_to_anchor=(2.1,0.5))
         plt.show()

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -24,18 +24,24 @@ def visualize_central_slices(I, vmax_scale=5, contour=False):
         ax1.contourf(I[int(map_shape[0] / 2), :, :], origin='upper')
         ax2.contourf(I[:, int(map_shape[1] / 2), :], origin='upper')
         ax3.contourf(I[:, :, int(map_shape[2] / 2)], origin='upper')
+
+        ax1.set_title("View along h", fontsize=14)
+        ax2.set_title("View along k", fontsize=14)
+        ax3.set_title("View along l", fontsize=14)
+
     else:
         ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=vmax)
         ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=vmax)
         ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=vmax)
 
+        ax1.set_title("(0,k,l)", fontsize=14)
+        ax2.set_title("(h,0,l)", fontsize=14)
+        ax3.set_title("(h,k,0)", fontsize=14)
+
     ax1.set_aspect(map_shape[2]/map_shape[1])
     ax2.set_aspect(map_shape[2]/map_shape[0])
     ax3.set_aspect(map_shape[1]/map_shape[0])
 
-    ax1.set_title("(0,k,l)", fontsize=14)
-    ax2.set_title("(h,0,l)", fontsize=14)
-    ax3.set_title("(h,k,0)", fontsize=14)
 
     for ax in [ax1,ax2,ax3]:
         ax.set_xticks([])

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -290,8 +290,8 @@ class PhononPlots:
                         ax.set_xlabel('phonon wavector')
                     if gs_j == 0:
                         ax.set_ylabel('phonon frequency')
-                if i_curve == 0:
-                    ax.legend()
+                if i_curve == 3:
+                    ax.legend(bbox_to_anchor=(1.1,0.5))
                 ax.set_title(title[i_curve])
             else:
                 ax.hist(np.sqrt(1. / np.real(self.phonon.Winv).flatten()),

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -4,7 +4,7 @@ from matplotlib.gridspec import GridSpec
 import numpy as np
 import plotly.graph_objects as go
 
-def visualize_central_slices(I, vmax_scale=5):
+def visualize_central_slices(I, vmax_scale=5, contour=False):
     """
     Plot central slices from the input map,  assuming
     that the map is centered around h,k,l=(0,0,0).
@@ -19,10 +19,15 @@ def visualize_central_slices(I, vmax_scale=5):
     f, (ax1,ax2,ax3) = plt.subplots(1, 3, figsize=(12,4))
     map_shape = I.shape
     vmax = I[~np.isnan(I)].mean()*vmax_scale
-    
-    ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=vmax)
-    ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=vmax)
-    ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=vmax)
+
+    if contour:
+        ax1.contourf(I[int(map_shape[0] / 2), :, :], origin='upper')
+        ax2.contourf(I[:, int(map_shape[1] / 2), :], origin='upper')
+        ax3.contourf(I[:, :, int(map_shape[2] / 2)], origin='upper')
+    else:
+        ax1.imshow(I[int(map_shape[0]/2),:,:], vmax=vmax)
+        ax2.imshow(I[:,int(map_shape[1]/2),:], vmax=vmax)
+        ax3.imshow(I[:,:,int(map_shape[2]/2)], vmax=vmax)
 
     ax1.set_aspect(map_shape[2]/map_shape[1])
     ax2.set_aspect(map_shape[2]/map_shape[0])

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -252,7 +252,8 @@ class PhononPlots:
     def dispersion_curve(self):
         nrows = 2
         ncols = 4
-        fig = plt.figure(figsize=(2 * ncols, 2 * nrows), constrained_layout=True)
+        fig = plt.figure(figsize=(2 * ncols, 2 * nrows), dpi=180,
+                         constrained_layout=True)
         gs = GridSpec(nrows, ncols, figure=fig)
 
         title   = ['0->h','0->k','0->l','0->h+k','0->h+l','0->k+l','0->h+k+l']
@@ -273,11 +274,13 @@ class PhononPlots:
                                                    k=k_curve[i_curve],
                                                    l=l_curve[i_curve])
                 for i in range(wvec.shape[-1]):
-                    ax.plot(knorm, wvec[:, i], 'o')
+                    ax.plot(knorm, wvec[:, i], 'o', label=f'#{i}')
                     if gs_i == 1:
                         ax.set_xlabel('phonon wavector')
                     if gs_j == 0:
                         ax.set_ylabel('phonon frequency')
+                if i_curve == 0:
+                    ax.legend()
                 ax.set_title(title[i_curve])
             else:
                 ax.hist(np.sqrt(1. / np.real(self.phonon.Winv).flatten()),
@@ -286,3 +289,35 @@ class PhononPlots:
         plt.tight_layout()
         plt.show()
 
+    def contribution_curve(self):
+        nrows=2
+        ncols=3
+        fig = plt.figure(figsize=(2 * ncols, 2 * nrows), dpi=180,
+                         constrained_layout=True)
+        gs = GridSpec(nrows, ncols, figure=fig)
+        knorm = self.phonon.kvec_norm.reshape(-1,1)
+        Winv2 = np.real(self.phonon.Winv).reshape(-1,6)
+        Vvec  = self.phonon.V.reshape(-1,6,6)
+        A = ['x', 'y', 'z', 'r1', 'r2', 'r3']
+
+        for i_curve in range(6):
+            gs_j = i_curve % ncols
+            gs_i = i_curve // ncols
+            ax = fig.add_subplot(gs[gs_i, gs_j])
+            if i_curve == 0:
+                ax_save = ax
+            ax.sharex(ax_save)
+            ax.sharey(ax_save)
+            for i in range(6):
+                ax.plot(knorm,
+                        Winv2[:,i_curve]*np.abs(Vvec[:,i,i_curve]),
+                        '.', label=f'{A[i]}')
+            ax.set_title(f'#{i_curve}')
+            if gs_i == 1:
+                ax.set_xlabel('phonon wavector')
+            if gs_j == 0:
+                ax.set_ylabel('phonon intensity')
+            ax.set_yscale('log')
+            if i_curve == 0:
+                ax.legend()
+        plt.show()


### PR DESCRIPTION
OnePhonon can now output diffuse intensity maps for each phonon/rank (see `eryx.models.OnePhonon.apply_disorder()`. This might be useful to evaluate the relative contribution of acoustic phonons relative to optical ones.

New visuals for `OnePhonon`:
- dispersion curve:
```python
from eryx.models import OnePhonon
from eryx.visuals import PhononPlots

hsampling, ksampling, lsampling = (-2,2,25), (-2,2,25), (-2,2,25)
funon = OnePhonon(pdb_path,hsampling,ksampling,lsampling)

phonon_plots = PhononPlots(funon)
phonon_plots.dispersion_curve()
```
![output](https://user-images.githubusercontent.com/4610338/215703034-78d24626-0c6e-4030-aa41-3c31e8cb10bd.png)

- contribution curve: illustrates how much each phonon contribute to the diffuse intensity and how each degree-of-freedom (translational or rotational) contributes respective to the others:
```python
phonon_plots.contribution_curve()
```
![output](https://user-images.githubusercontent.com/4610338/215703333-e28518f3-6770-49a9-8110-6a2b5f8e0d13.png)

Also added the `OnePhononBrillouin` class to specifically study given Bragg peaks. For example:
```python
brillouin = OnePhononBrillouin(pdb_path, 7,7,7,13)
visualize_central_slices(brillouin.Id, contour=True)
```
![output](https://user-images.githubusercontent.com/4610338/215724132-bbed24a4-497b-4745-90ff-9454f76aa5be.png)
```python
brillouin2 = OnePhononBrillouin(pdb_path, 7,7,7,13, gnm_cutoff=10.)
visualize_central_slices(brillouin2.Id, contour=True)
```
![output](https://user-images.githubusercontent.com/4610338/215724288-0d8a7ef9-8167-4271-9eff-67c4d85ec712.png)
```python
brillouin3 = OnePhononBrillouin(pdb_path, 7,7,7,13,
                                gamma_intra=10.)
visualize_central_slices(brillouin3.Id, contour=True)
```
![output](https://user-images.githubusercontent.com/4610338/215724432-8de837e7-21a0-4807-98d4-a55ac7bd0f09.png)
