### PR TITLE
`OnePhonon` covariance

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -979,6 +979,7 @@ class OnePhonon:
         if model == 'gnm':
             self._setup_gnm(pdb_path, gnm_cutoff, gamma_intra, gamma_inter)
             self.compute_gnm_phonons()
+            self.compute_covariance_matrix()
         else:
             self.compute_rb_phonons()
 
@@ -1214,6 +1215,38 @@ class OnePhonon:
 
         return hessian
 
+    def compute_covariance_matrix(self):
+        """
+        Compute covariance matrix for all asymmetric units.
+        The covariance matrix results from modelling pairwise
+        interactions with a Gaussian Network Model where atom
+        pairs belonging to different asymmetric units are not
+        interacting. It is scaled to match the ADPs in the input PDB file.
+        """
+        self.covar = np.zeros((self.n_asu*self.n_dof_per_asu,
+                               self.n_cell, self.n_asu*self.n_dof_per_asu),
+                              dtype='complex')
+
+        hessian = self.compute_hessian()
+        for dh in range(self.hsampling[2]):
+            for dk in range(self.ksampling[2]):
+                for dl in range(self.lsampling[2]):
+                    kvec = self.kvec[dh,dk,dl]
+                    Kinv = self.gnm.compute_Kinv(hessian, kvec=kvec, reshape=False)
+                    for j_cell in range(self.n_cell):
+                        r_cell = self.crystal.get_unitcell_origin(self.crystal.id_to_hkl(j_cell))
+                        phase = np.dot(kvec, r_cell)
+                        eikr = np.cos(phase) + 1j * np.sin(phase)
+                        self.covar[:,j_cell,:] += Kinv * eikr
+        ADP_scale = np.mean(self.model.adp[0]) / \
+                    (8 * np.pi * np.pi * np.mean(np.diag(self.covar[:,self.crystal.hkl_to_id([0,0,0]),:])) / 3.)
+        self.covar *= ADP_scale
+        self.ADP = np.real(np.diag(self.covar[:,self.crystal.hkl_to_id([0,0,0]),:]))
+        self.ADP = self.Amat[0] @ self.ADP
+        self.ADP = np.sum(self.ADP.reshape(int(self.ADP.shape[0]/3),3),axis=1)
+        self.covar = np.real(self.covar.reshape((self.n_asu, self.n_dof_per_asu,
+                                                 self.n_cell, self.n_asu, self.n_dof_per_asu)))
+
     def compute_gnm_phonons(self):
         """
         Compute the dynamical matrix for each k-vector in the first
@@ -1286,7 +1319,7 @@ class OnePhonon:
                             self.model.ff_a[i_asu],
                             self.model.ff_b[i_asu],
                             self.model.ff_c[i_asu],
-                            U=None,
+                            U=self.ADP,
                             batch_size=self.batch_size,
                             n_processes=self.n_processes,
                             compute_qF=True,

--- a/eryx/pdb.py
+++ b/eryx/pdb.py
@@ -620,7 +620,7 @@ class GaussianNetworkModel:
                     Kmat[i_asu, :, j_asu, :] += hessian[i_asu, :, j_cell, j_asu, :] * eikr
         return Kmat
 
-    def compute_Kinv(self, hessian, kvec=None):
+    def compute_Kinv(self, hessian, kvec=None, reshape=True):
         """
         Compute the inverse of K(kvec)
         (see compute_K() for the relationship between K and the hessian).
@@ -644,6 +644,7 @@ class GaussianNetworkModel:
         Kshape = Kmat.shape
         Kinv = np.linalg.pinv(Kmat.reshape(Kshape[0] * Kshape[1],
                                            Kshape[2] * Kshape[3]))
-        Kinv = Kinv.reshape((Kshape[0], Kshape[1],
-                             Kshape[2], Kshape[3]))
+        if reshape:
+            Kinv = Kinv.reshape((Kshape[0], Kshape[1],
+                                 Kshape[2], Kshape[3]))
         return Kinv


### PR DESCRIPTION
Added computing of covariance for OnePhonon model and associated visuals. Now the ADP is computed, used to scale the covariance and applied to the diffuse intensity.

```python

hsampling, ksampling, lsampling = (-3,3,13), (-3,3,13), (-1,1,13)
funon = OnePhonon(pdb_path, hsampling,ksampling,lsampling,
                  gnm_cutoff=4., gamma_intra=2,gamma_inter=1)
Id = funon.apply_disorder()
visualize_central_slices(Id.reshape(funon.map_shape))
```
![image](https://user-images.githubusercontent.com/4610338/215972431-9c449b7b-a115-4c35-a4ac-d9ce19232dc3.png)


Turning off the ADP results in:
```python
funon.ADP = None
Id = funon.apply_disorder()
visualize_central_slices(Id.reshape(funon.map_shape))
```
![image](https://user-images.githubusercontent.com/4610338/215972550-b79d4393-e8e1-4c1f-bef1-f05b68224d39.png)

The main covariances between the central unit cell and its nearest neighbors can be examined:
```python
crystal_vision = VisualizeCrystal(funon.gnm.crystal, onephonon=funon)
crystal_vision.color_by = 'unit_cell'
crystal_vision.show()
```
![image](https://user-images.githubusercontent.com/4610338/215972687-0c895479-65ac-4422-8920-e42546403cf9.png)
