### PR TITLE
`DeltaPDF` class to visualize 3D diffuse patterson.

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -865,7 +865,7 @@ class NonInteractingDeformableMolecules:
             Id = self.compute_scl_intensity()
         else:
             Id = self.compute_intensity_naive()
-        Id[:, ~self.res_mask] = np.nan
+        Id[~self.res_mask] = np.nan
         return Id
 
 class OnePhonon:

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -367,7 +367,7 @@ class PhononPlots:
 
 class DeltaPDF:
 
-    def __init__(self, disorder_model, Id=None):
+    def __init__(self, disorder_model, Id=None, fill_bragg=True:
         self.disorder_model = disorder_model
         self.q_grid = self.disorder_model.q_grid
         self.pdf = None
@@ -375,7 +375,8 @@ class DeltaPDF:
             self.Id = Id
         else:
             self.Id = self.disorder_model.apply_disorder()
-        self._fill_integral_Miller_points()
+        if fill_bragg:
+            self._fill_integral_Miller_points()
         self._subtract_radial_average()
 
     def _fill_integral_Miller_points(self):

--- a/eryx/visuals.py
+++ b/eryx/visuals.py
@@ -4,7 +4,7 @@ from matplotlib.gridspec import GridSpec
 import numpy as np
 import plotly.graph_objects as go
 
-def visualize_central_slices(I, vmax_scale=5, contour=False):
+def visualize_central_slices(I, vmax_scale=5, contour=False, contour_cmap=None):
     """
     Plot central slices from the input map,  assuming
     that the map is centered around h,k,l=(0,0,0).
@@ -21,9 +21,11 @@ def visualize_central_slices(I, vmax_scale=5, contour=False):
     vmax = I[~np.isnan(I)].mean()*vmax_scale
 
     if contour:
-        ax1.contourf(I[int(map_shape[0] / 2), :, :], origin='upper')
-        ax2.contourf(I[:, int(map_shape[1] / 2), :], origin='upper')
-        ax3.contourf(I[:, :, int(map_shape[2] / 2)], origin='upper')
+        if contour_cmap is None:
+            contour_cmap = 'viridis'
+        ax1.contourf(I[int(map_shape[0] / 2), :, :], origin='upper', cmap=contour_cmap)
+        ax2.contourf(I[:, int(map_shape[1] / 2), :], origin='upper', cmap=contour_cmap)
+        ax3.contourf(I[:, :, int(map_shape[2] / 2)], origin='upper', cmap=contour_cmap)
 
         ax1.set_title("View along h", fontsize=14)
         ax2.set_title("View along k", fontsize=14)
@@ -362,3 +364,33 @@ class PhononPlots:
             if i_curve == 2:
                 ax.legend(bbox_to_anchor=(2.1,0.5))
         plt.show()
+
+class DeltaPDF:
+
+    def __init__(self, disorder_model, Id=None):
+        self.disorder_model = disorder_model
+        self.q_grid = self.disorder_model.q_grid
+        self.pdf = None
+        if Id is not None:
+            self.Id = Id
+        else:
+            self.Id = self.disorder_model.apply_disorder()
+        self._subtract_radial_average()
+
+    def _subtract_radial_average(self):
+        q2 = np.linalg.norm(self.q_grid, axis=1) ** 2
+        q2_unique, q2_unique_inverse = np.unique(np.round(q2, 2),
+                                                 return_inverse=True)
+        for i in range(q2_unique.shape[0]):
+            self.Id[np.round(q2, 2) == q2_unique[i]] -= \
+                np.mean(self.If[np.round(q2, 2) == q2_unique[i]])
+
+    def compute_patterson(self):
+        np.nan_to_num(self.Id, copy=False, nan=0.0)
+        self.pdf = np.real(np.fft.fftshift(np.fft.fftn(np.fft.ifftshift(self.Id.reshape(self.map_shape)))))
+
+    def show(self, contour=False):
+        if self.pdf is None:
+            self.compute_patterson()
+        visualize_central_slices(self.pdf, contour=contour, contour_cmap='seismic')
+


### PR DESCRIPTION
To visualize the 3D Patterson - aka the Fourier transform of the diffuse intensity (see Meisburger et al), one can:
```python
from eryx.models import OnePhonon
from eryx.visuals import DeltaPDF

hsampling, ksampling, lsampling = (-7,7,7), (-7,7,7), (-7,7,7)
funon = OnePhonon(pdb_path, hsampling,ksampling,lsampling,
                  gnm_cutoff=4., gamma_intra=2,gamma_inter=1)
delta_pdf = DeltaPDF(funon)
delta_pdf.show(contour=True)
```
![output](https://user-images.githubusercontent.com/4610338/216012542-1ab44c6a-e3eb-4ab2-a038-2b18a3d3906e.png)

For reference, the diffuse intensity map can be visualized:
```python
visualize_central_slices(delta_pdf.Id.reshape(delta_pdf.disorder_model.map_shape), contour=True, contour_cmap='seismic')
```
![output](https://user-images.githubusercontent.com/4610338/216013354-44f1f735-f4a1-47a7-a9b7-8a3bc476f07d.png)
