### PR TITLE
fixed dimension issue in OnePhonon when multiple ASUs in the unit cell

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -1271,9 +1271,10 @@ class OnePhonon:
         #            (8 * np.pi * np.pi * np.mean(np.diag(self.covar[:,self.crystal.hkl_to_id([0,0,0]),:])) / 3.)
         #self.covar *= ADP_scale
         self.ADP = np.real(np.diag(self.covar[:,self.crystal.hkl_to_id([0,0,0]),:]))
-        self.ADP = self.Amat[0] @ self.ADP
+        Amat = np.transpose(self.Amat, (1,0,2)).reshape(self.n_dof_per_asu_actual, self.n_asu*self.n_dof_per_asu)
+        self.ADP = Amat @ self.ADP
         self.ADP = np.sum(self.ADP.reshape(int(self.ADP.shape[0]/3),3),axis=1)
-        ADP_scale = np.mean(self.model.adp[0]) / (8*np.pi*np.pi*np.mean(self.ADP)/3)
+        ADP_scale = np.mean(self.model.adp) / (8*np.pi*np.pi*np.mean(self.ADP)/3)
         self.ADP *= ADP_scale
         self.covar *= ADP_scale
         self.covar = np.real(self.covar.reshape((self.n_asu, self.n_dof_per_asu,

--- a/eryx/pdb.py
+++ b/eryx/pdb.py
@@ -136,7 +136,10 @@ class AtomicModel:
             self.structure.remove_alternative_conformations()
             self.structure.remove_hydrogens()
             self.structure.remove_waters()
-            self.structure.remove_ligands_and_waters()
+            try:
+                self.structure.remove_ligands_and_waters()
+            except RuntimeError as e:
+                print(e)
             self.structure.remove_empty_chains()
 
     def _extract_cell(self):


### PR DESCRIPTION
Closes #48 . Also catches a `gemmi` error.

Test (on P222):
```python
pdb_path='../tests/pdbs/2vj4.pdb'
start = time.time()
p222 = OnePhonon(pdb_path, (-10,10,3), (-10,10,3), (-10,10,3), res_limit=1.5, gamma_inter=1.)
print(f"elapsed time: {(time.time()-start)/60.0}")
Id_p222 = p222.apply_disorder()
visualize_central_slices(Id_p222.reshape(p222.map_shape))
```
Result:
```python
elapsed time: 16.312842484315237
100%|██████████| 3/3 [07:54<00:00, 158.15s/it]
```
![p222](https://github.com/apeck12/eryx/assets/4610338/fd84fd27-d161-4465-8359-4e5d434417ad)

Note: on P212121 we do not get the right symmetry - see cypa below for example:
![p212121](https://github.com/apeck12/eryx/assets/4610338/5d180f94-175b-49ee-8e60-ef13630cfcb3)
