### PR TITLE
Use experimental adps in Guinier's equation

### DIFF
--- a/eryx/models.py
+++ b/eryx/models.py
@@ -631,6 +631,7 @@ class Ensemble:
 
             for conf in range(self.model.n_conf):
                 index = conf * self.model.n_asu + asu
+                U = self.model.adp[index] / (8 * np.pi * np.pi)
                 A = structure_factors(self.q_grid[self.mask], 
                                       self.model.xyz[index], 
                                       self.model.ff_a[index], 

--- a/eryx/models.py
+++ b/eryx/models.py
@@ -498,13 +498,14 @@ class RigidBodyRotations:
                 # apply Guinier's equation to rotated ensemble
                 fc = np.zeros(self.q_grid.shape[0], dtype=complex)
                 fc_square = np.zeros(self.q_grid.shape[0])
+                U = self.model.adp[asu] / (8 * np.pi * np.pi)
                 for rnum in range(num_rot):
                     A = structure_factors(self.q_grid[self.mask], 
                                           xyz_rot[rnum], 
                                           self.model.ff_a[asu], 
                                           self.model.ff_b[asu], 
                                           self.model.ff_c[asu], 
-                                          U=None, 
+                                          U=U, 
                                           batch_size=self.batch_size,
                                           n_processes=self.n_processes)
                     if ensemble_dir is not None:
@@ -637,7 +638,7 @@ class Ensemble:
                                       self.model.ff_a[index], 
                                       self.model.ff_b[index], 
                                       self.model.ff_c[index], 
-                                      U=None, 
+                                      U=U, 
                                       batch_size=self.batch_size,
                                       n_processes=self.n_processes)
 

--- a/eryx/pdb.py
+++ b/eryx/pdb.py
@@ -211,8 +211,8 @@ class AtomicModel:
             model = self.structure[fr]
             residues = [res for ch in model for res in ch]
             self._extract_xyz(residues, expand_p1)
-            self._extract_adp(residues, expand_p1)
-            self._extract_ff_coefs(residues, expand_p1)
+        self._extract_adp(residues, expand_p1)
+        self._extract_ff_coefs(residues, expand_p1)
         
     def _get_xyz_asus(self, xyz):
         """


### PR DESCRIPTION
ADPs are now retrieved from the PDB file and applied to calculate the structure factors when using Guinier's equation (`RigidBodyRotations` and `Ensemble` classes). The effect is to radially redistribute the intensity in reciprocal space, as shown below in comparing plots for a CypA ensemble without the B-factors set to zero:
![download-5](https://github.com/apeck12/eryx/assets/6363287/8684635a-b248-4b8d-a149-52776de42e2e)
and randomly chosen B-factors ranging from 5-20 Å for each atom:
![download-7](https://github.com/apeck12/eryx/assets/6363287/e52b9a24-5c08-4307-8a5e-80732647efde)

There's also a fix to the `AtomicModel` class, which had duplicated entries in the form factors and adp self variables for multi-conformer PDB files.

(Reference: https://www.theguardian.com/us-news/2023/apr/03/train-derailment-western-montana-beer-spill)