### PR TITLE
fixing adp expansion

### DIFF
--- a/eryx/pdb.py
+++ b/eryx/pdb.py
@@ -211,8 +211,12 @@ class AtomicModel:
             model = self.structure[fr]
             residues = [res for ch in model for res in ch]
             self._extract_xyz(residues, expand_p1)
-        self._extract_adp(residues, expand_p1)
-        self._extract_ff_coefs(residues, expand_p1)
+            if not expand_p1:
+                self._extract_adp(residues, expand_p1)
+                self._extract_ff_coefs(residues, expand_p1)
+        if expand_p1:
+            self._extract_adp(residues, expand_p1)
+            self._extract_ff_coefs(residues, expand_p1)
         
     def _get_xyz_asus(self, xyz):
         """


### PR DESCRIPTION
A previous change to the `AtomicModel` class was causing it to not expand the ADP and form factors self variables properly for the case of the PDB being pre-expanded to P1 (e.g. in Chimera). This fixes that error; all unit tests now passing.