### PR TITLE
update gemmi way to load fractionalize_matrix from pdb cell

### DIFF
--- a/eryx/pdb.py
+++ b/eryx/pdb.py
@@ -147,7 +147,7 @@ class AtomicModel:
         Extract unit cell information.
         """
         self.cell = np.array(self.structure.cell.parameters)
-        self.A_inv = np.array(self.structure.cell.fractionalization_matrix)
+        self.A_inv = np.array(self.structure.cell.frac.mat)
         self.space_group = self.structure.spacegroup_hm
         self.unit_cell_axes = get_unit_cell_axes(self.cell)
         


### PR DESCRIPTION
Fixed the following error:
```
AttributeError: 'UnitCell' object has no attribute 'fractionalization_matrix'
```
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/d301a1f7-e988-4f7a-8a6d-cdc04e988c11" />
